### PR TITLE
AutoQEC Day-2 — handshake + machine_state + round-dir layout (Chen Jiahan)

### DIFF
--- a/autoqec/example_db/handshake_stub.yaml
+++ b/autoqec/example_db/handshake_stub.yaml
@@ -1,0 +1,20 @@
+# Minimal Tier-1 GNN config used by scripts/e2e_handshake.py to prove the
+# orchestration ↔ Runner contract end-to-end without an LLM in the loop.
+# Kept deliberately tiny so a dev-profile round completes in seconds.
+type: gnn
+output_mode: soft_priors
+gnn:
+  layers: 2
+  hidden_dim: 16
+  message_fn: mlp
+  aggregation: sum
+  normalization: layer
+  residual: false
+  edge_features: [syndrome_bit]
+head: linear
+training:
+  learning_rate: 1.0e-3
+  batch_size: 64
+  epochs: 1
+  loss: bce
+  profile: dev

--- a/autoqec/tools/machine_state.py
+++ b/autoqec/tools/machine_state.py
@@ -1,0 +1,80 @@
+"""Machine state probe (Task A2.2).
+
+Surfaced to the Ideator subagent as `machine_state_hint` so it can
+calibrate candidate size against observed GPU budget + round timings.
+
+Everything except the GPU section is torch-free, so this module imports
+cleanly in lean CI environments. Torch is imported lazily inside
+`_gpu_snapshot` and any failure (missing module, driver error, no CUDA
+device) returns an empty dict rather than raising.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _load_history(run_dir: Path) -> list[dict]:
+    history_path = run_dir / "history.jsonl"
+    if not history_path.exists():
+        return []
+    with history_path.open(encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _gpu_snapshot() -> dict:
+    try:
+        import torch  # noqa: PLC0415 — intentional lazy import
+    except ImportError:
+        return {}
+    if not torch.cuda.is_available():
+        return {}
+    try:
+        free, _total = torch.cuda.mem_get_info()
+        return {
+            "name": torch.cuda.get_device_name(0),
+            "vram_total_gb": torch.cuda.get_device_properties(0).total_memory / 1e9,
+            "vram_free_gb": free / 1e9,
+        }
+    except Exception:  # pragma: no cover — driver-specific
+        return {}
+
+
+def machine_state(
+    run_dir: str | Path,
+    *,
+    total_wallclock_s_budget: float | None = None,
+) -> dict:
+    """Compose a snapshot for the Ideator's L3 context.
+
+    `total_wallclock_s_budget` is the outer budget the orchestrator
+    enforces; `total_wallclock_s_remaining` is derived from it minus spent.
+    """
+    run_dir = Path(run_dir)
+    history = _load_history(run_dir)
+    timings = [
+        float(r.get("train_wallclock_s", 0) or 0) + float(r.get("eval_wallclock_s", 0) or 0)
+        for r in history
+    ]
+    killed = sum(1 for r in history if r.get("status") == "killed_by_safety")
+    n = len(timings)
+    wall_mean = (sum(timings) / n) if n else 0
+    wall_p95 = sorted(timings)[min(int(0.95 * n), max(n - 1, 0))] if n else 0
+    params_vs_time = [(int(r.get("n_params", 0) or 0), t) for r, t in zip(history, timings)]
+    spent = sum(timings)
+    remaining = (total_wallclock_s_budget - spent) if total_wallclock_s_budget is not None else None
+
+    return {
+        "gpu": _gpu_snapshot(),
+        "history_timings": {
+            "rounds_so_far": n,
+            "wall_clock_mean_s": wall_mean,
+            "wall_clock_p95_s": wall_p95,
+            "params_vs_time": params_vs_time,
+            "killed_by_safety_count": killed,
+        },
+        "budget": {
+            "total_wallclock_s_spent": spent,
+            "total_wallclock_s_remaining": remaining,
+        },
+    }

--- a/autoqec/tools/machine_state.py
+++ b/autoqec/tools/machine_state.py
@@ -23,20 +23,25 @@ def _load_history(run_dir: Path) -> list[dict]:
 
 
 def _gpu_snapshot() -> dict:
+    """Probe CUDA without letting any failure leak out.
+
+    The whole chain (import → is_available → mem_get_info → device
+    properties) sits inside one `try` because a mis-configured driver
+    can raise at *any* of those steps, and the Ideator prompt assembly
+    must not crash when a GPU probe fails.
+    """
     try:
         import torch  # noqa: PLC0415 — intentional lazy import
-    except ImportError:
-        return {}
-    if not torch.cuda.is_available():
-        return {}
-    try:
+
+        if not torch.cuda.is_available():
+            return {}
         free, _total = torch.cuda.mem_get_info()
         return {
             "name": torch.cuda.get_device_name(0),
             "vram_total_gb": torch.cuda.get_device_properties(0).total_memory / 1e9,
             "vram_free_gb": free / 1e9,
         }
-    except Exception:  # pragma: no cover — driver-specific
+    except Exception:
         return {}
 
 

--- a/docs/contracts/round_dir_layout.md
+++ b/docs/contracts/round_dir_layout.md
@@ -5,6 +5,13 @@
 sign-off. Do not rename fields here without updating
 `docs/contracts/interfaces.md` §2.2 and the Runner + orchestration tests.
 
+**Reading convention**
+
+- Statements in this doc describe **current behaviour** of the code on
+  `main` + `feat/chen-orchestration` as of 2026-04-21.
+- Known gaps between this doc and current code are tagged
+  **[TODO-fill-in]** and name the owner who should close them.
+
 ## Directory shape
 
 ```
@@ -67,7 +74,16 @@ The names it does add are frozen here:
 
 ### `metrics.json` — exactly `RoundMetrics` (§2.2)
 
-Absolute paths for `checkpoint_path` and `training_log_path`. No extra keys.
+`checkpoint_path` and `training_log_path` inherit the absoluteness of the
+`RunnerConfig.round_dir` the caller passes in. `scripts/e2e_handshake.py`
+and `scripts/run_single_round.py` pass absolute paths (via
+`Path(...).resolve()`), so their rounds record absolute paths in
+`metrics.json`. **[TODO-fill-in, Lin]** `cli/autoqec.py::run` currently
+composes `run_dir = Path("runs") / run_id` (cwd-relative) and forwards
+that to `RunnerConfig.round_dir` — tighten with `.resolve()` before
+passing, so every writer produces absolute paths regardless of cwd.
+
+No extra keys beyond `RoundMetrics`.
 
 ### `pareto.json` — list of dicts, sorted by `-delta_ler`
 
@@ -93,24 +109,40 @@ The same DSL dict that the Coder subagent produced, validated against
 
 ### `train.log` — `<step_idx>\t<loss>` per line
 
-Tab-separated. One line per batch. Used by `/diagnose-failure` and by
-the `machine_state` `params_vs_time` scatter.
+Tab-separated. One line per batch. Consumed by `/diagnose-failure`
+(Xie, Day-3). The `machine_state` `params_vs_time` scatter does **not**
+read `train.log` — it derives `(n_params, train_wallclock_s +
+eval_wallclock_s)` from `history.jsonl`.
 
-## Invariants (enforced by tests)
+## Invariants
 
-- `round_<N>/` exists **before** any `history.jsonl` entry with
-  `round == N` is written. (Covered by integration test in
-  `test_runner_smoke.py`; expand in Day-3.)
-- `metrics.json` `checkpoint_path` points inside `round_<N>/`.
-  (Covered in `test_orchestration_stub.py::test_l3_for_analyst_metrics_path_is_absolute`
-  for the path-resolution half; Runner-side covered by `test_runner_smoke`.)
-- Text files are UTF-8. Windows CI must not fall back to the locale
-  code page. (Covered in
-  `test_orchestration_stub.py::test_run_memory_append_log_roundtrips_utf8`.)
+**Enforced now:**
+
+- Orchestration-written text files (`history.jsonl`, `log.md`,
+  `pareto.json`) are opened with explicit `encoding="utf-8"` and
+  `json.dumps(..., ensure_ascii=False)` — Chinese, Δ, and other
+  non-ASCII content round-trips cleanly on Windows. Covered in
+  `test_orchestration_stub.py::test_run_memory_append_log_roundtrips_utf8`.
 - Subagent response JSON validates against
   `IdeatorResponse`/`CoderResponse`/`AnalystResponse` before its
-  contents are mirrored into `history.jsonl`. (Covered in
-  `test_orchestration_stub.py::test_parse_response_enforces_*`.)
+  contents are mirrored into `history.jsonl`. Covered in
+  `test_orchestration_stub.py::test_parse_response_enforces_*`.
+- `l3_for_analyst` passes an absolute `metrics_path` to the Analyst
+  even when the caller supplied a relative `round_dir`. Covered in
+  `test_orchestration_stub.py::test_l3_for_analyst_metrics_path_is_absolute`.
+- `_gpu_snapshot` returns `{}` on any CUDA/driver failure, not just
+  missing torch. Covered in
+  `test_machine_state.py::test_gpu_snapshot_swallows_driver_errors_from_is_available`.
+
+**[TODO-fill-in] aspirational, not enforced yet:**
+
+- `round_<N>/` exists **before** any `history.jsonl` entry with
+  `round == N` is written. (Needs a cross-component integration test in
+  Day-3 after the orchestrator → Runner loop is wired.)
+- Runner-written text files (`config.yaml`, `train.log`, `metrics.json`)
+  use `encoding="utf-8"` — current Runner code relies on locale default
+  (see `autoqec/runner/runner.py:61, 163, 230`). **[TODO-fill-in, Lin]**
+  add explicit `encoding="utf-8"`.
 
 ## Non-goals
 

--- a/docs/contracts/round_dir_layout.md
+++ b/docs/contracts/round_dir_layout.md
@@ -1,0 +1,121 @@
+# Round-dir + run-dir layout
+
+**Frozen on:** 2026-04-21 (Day-2 handshake, Chen Jiahan)
+**Change policy:** edits require PR touching this file with Chen / Lin / Xie
+sign-off. Do not rename fields here without updating
+`docs/contracts/interfaces.md` §2.2 and the Runner + orchestration tests.
+
+## Directory shape
+
+```
+runs/<run_id>/                 ← the RUN (one /autoqec-run invocation)
+├── history.jsonl              ← orchestration: one line per round
+├── log.md                     ← orchestration: narrative, human-readable
+├── pareto.json                ← orchestration: current Pareto front (≤ 5)
+└── round_<N>/                 ← one ROUND (one Runner invocation)
+    ├── config.yaml            ← Runner: dump of predecoder_config dict
+    ├── train.log              ← Runner: one `<step>\t<loss>` per line
+    ├── checkpoint.pt          ← Runner: state_dict + dsl_config + output_mode
+    ├── metrics.json           ← Runner: RoundMetrics dump (§2.2)
+    └── verification_report.md ← Verifier (Xie, Day-3): VerifyReport prose
+```
+
+`<run_id>` is UTC `YYYYMMDD-HHMMSS` (produced by `cli/autoqec.py::run`).
+
+## Writer ownership (no file is written by two sides)
+
+| Path | Writer | When |
+|---|---|---|
+| `runs/<run_id>/` | `cli/autoqec.py::run` | on run start |
+| `history.jsonl` | `RunMemory.append_round` | after each round's Runner + Analyst |
+| `log.md` | `RunMemory.append_log` | after each round's Analyst |
+| `pareto.json` | `RunMemory.update_pareto` | after the Pareto refresh at round end |
+| `round_<N>/` | `run_round` | at round start |
+| `config.yaml` | `run_round` | before training |
+| `train.log` | `run_round` | during training (overwritten once at end) |
+| `checkpoint.pt` | `run_round` | after training |
+| `metrics.json` | `run_round` | at round end |
+| `verification_report.md` | Verifier (Xie) | when the Analyst verdict is `candidate` |
+
+The orchestration side writes **only** at the run root; the Runner writes
+**only** inside `round_<N>/`. The two sides never race on the same file.
+
+## Reader contract
+
+| Reader | Reads | Purpose |
+|---|---|---|
+| Analyst subagent | `round_<N>/metrics.json` | Round summary + verdict |
+| Ideator subagent | `history.jsonl`, `pareto.json` (via L3) | Avoid re-proposal, target Pareto gaps |
+| `machine_state` tool | `history.jsonl` | Round timings + killed counts |
+| Verifier (Day-3) | `round_<N>/checkpoint.pt`, `round_<N>/config.yaml` | Independent holdout eval |
+| `/review-log` skill | `log.md`, `history.jsonl` | Retrospective |
+
+## Required fields per file
+
+### `history.jsonl` — one line per round, superset of `RoundMetrics`
+
+The orchestrator is free to add keys on top of the `RoundMetrics` dump.
+The names it does add are frozen here:
+
+- `round` — int, 1-indexed
+- `hypothesis` — str, the Ideator's one-sentence proposal
+- `verdict` — `"candidate"` or `"ignore"` from the Analyst
+- plus every field in `RoundMetrics` (`status`, `delta_ler`,
+  `ler_plain_classical`, `ler_predecoder`, `flops_per_syndrome`,
+  `n_params`, `train_wallclock_s`, `eval_wallclock_s`, `vram_peak_gb`,
+  `checkpoint_path`, `training_log_path`, `status_reason` when not `ok`)
+
+### `metrics.json` — exactly `RoundMetrics` (§2.2)
+
+Absolute paths for `checkpoint_path` and `training_log_path`. No extra keys.
+
+### `pareto.json` — list of dicts, sorted by `-delta_ler`
+
+Each entry at minimum: `{"round": int, "delta_ler": float,
+"flops_per_syndrome": int, "n_params": int, "checkpoint_path": str}`.
+Capped to 5 entries (longer fronts stored in `history.jsonl`).
+
+### `config.yaml` — literal dump of `RunnerConfig.predecoder_config`
+
+The same DSL dict that the Coder subagent produced, validated against
+`PredecoderDSL` before training starts.
+
+### `checkpoint.pt` — `torch.save` of
+
+```python
+{
+  "class_name": type(model).__name__,
+  "state_dict": model.state_dict(),
+  "output_mode": model.output_mode,   # "hard_flip" | "soft_priors"
+  "dsl_config": predecoder_config,    # same dict as config.yaml
+}
+```
+
+### `train.log` — `<step_idx>\t<loss>` per line
+
+Tab-separated. One line per batch. Used by `/diagnose-failure` and by
+the `machine_state` `params_vs_time` scatter.
+
+## Invariants (enforced by tests)
+
+- `round_<N>/` exists **before** any `history.jsonl` entry with
+  `round == N` is written. (Covered by integration test in
+  `test_runner_smoke.py`; expand in Day-3.)
+- `metrics.json` `checkpoint_path` points inside `round_<N>/`.
+  (Covered in `test_orchestration_stub.py::test_l3_for_analyst_metrics_path_is_absolute`
+  for the path-resolution half; Runner-side covered by `test_runner_smoke`.)
+- Text files are UTF-8. Windows CI must not fall back to the locale
+  code page. (Covered in
+  `test_orchestration_stub.py::test_run_memory_append_log_roundtrips_utf8`.)
+- Subagent response JSON validates against
+  `IdeatorResponse`/`CoderResponse`/`AnalystResponse` before its
+  contents are mirrored into `history.jsonl`. (Covered in
+  `test_orchestration_stub.py::test_parse_response_enforces_*`.)
+
+## Non-goals
+
+- No per-run database. `runs/` is append-only disk; post-processing can
+  build whatever index it wants on top of `history.jsonl`.
+- No automatic cleanup. Old `runs/` directories persist until a human
+  removes them; `.gitignore` already excludes the directory so this is
+  safe.

--- a/scripts/e2e_handshake.py
+++ b/scripts/e2e_handshake.py
@@ -16,30 +16,41 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-import yaml
+# Make the repo root importable and resolve shipped-config paths relative to
+# it, so `python /abs/path/to/scripts/e2e_handshake.py` works from any cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-from autoqec.envs.schema import load_env_yaml
-from autoqec.runner.schema import RunnerConfig
+import yaml  # noqa: E402
 
-DEFAULT_ENV_YAML = "autoqec/envs/builtin/surface_d5_depol.yaml"
-DEFAULT_STUB_YAML = "autoqec/example_db/handshake_stub.yaml"
+from autoqec.envs.schema import load_env_yaml  # noqa: E402
+from autoqec.runner.schema import RunnerConfig  # noqa: E402
+
+DEFAULT_ENV_YAML = _REPO_ROOT / "autoqec/envs/builtin/surface_d5_depol.yaml"
+DEFAULT_STUB_YAML = _REPO_ROOT / "autoqec/example_db/handshake_stub.yaml"
 
 
 def build_runner_config(
-    env_yaml: str | Path,
-    stub_yaml: str | Path,
+    env_yaml: str | Path | None,
+    stub_yaml: str | Path | None,
     round_dir: str | Path,
     seed: int = 0,
 ) -> RunnerConfig:
     """Load env + DSL stub and compose a RunnerConfig matching §2.2.
 
+    `env_yaml` / `stub_yaml` default to the shipped defaults anchored at
+    `_REPO_ROOT`, so callers running from any cwd get the same behaviour.
     Kept importable so the unit test can exercise the config-composition
     contract without touching torch.
     """
-    env = load_env_yaml(env_yaml)
-    cfg_dict = yaml.safe_load(Path(stub_yaml).read_text(encoding="utf-8"))
+    env_path = Path(env_yaml) if env_yaml is not None else DEFAULT_ENV_YAML
+    stub_path = Path(stub_yaml) if stub_yaml is not None else DEFAULT_STUB_YAML
+    env = load_env_yaml(env_path)
+    cfg_dict = yaml.safe_load(stub_path.read_text(encoding="utf-8"))
     return RunnerConfig(
         env_name=env.name,
         predecoder_config=cfg_dict,
@@ -50,8 +61,8 @@ def build_runner_config(
 
 
 def main(
-    env_yaml: str | Path = DEFAULT_ENV_YAML,
-    stub_yaml: str | Path = DEFAULT_STUB_YAML,
+    env_yaml: str | Path | None = None,
+    stub_yaml: str | Path | None = None,
     round_dir: str | Path = "runs/handshake/round_0",
     seed: int = 0,
 ) -> dict:
@@ -62,7 +73,8 @@ def main(
     """
     from autoqec.runner.runner import run_round  # noqa: PLC0415 — intentional lazy import
 
-    env = load_env_yaml(env_yaml)
+    env_path = Path(env_yaml) if env_yaml is not None else DEFAULT_ENV_YAML
+    env = load_env_yaml(env_path)
     cfg = build_runner_config(env_yaml, stub_yaml, round_dir, seed)
     metrics = run_round(cfg, env)
     print(metrics.model_dump_json(indent=2))
@@ -71,9 +83,9 @@ def main(
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--env-yaml", default=DEFAULT_ENV_YAML)
-    p.add_argument("--stub-yaml", default=DEFAULT_STUB_YAML)
-    p.add_argument("--round-dir", default="runs/handshake/round_0")
+    p.add_argument("--env-yaml", default=str(DEFAULT_ENV_YAML))
+    p.add_argument("--stub-yaml", default=str(DEFAULT_STUB_YAML))
+    p.add_argument("--round-dir", default=str(_REPO_ROOT / "runs/handshake/round_0"))
     p.add_argument("--seed", type=int, default=0)
     return p.parse_args()
 

--- a/scripts/e2e_handshake.py
+++ b/scripts/e2e_handshake.py
@@ -1,0 +1,88 @@
+"""Phase-2 end-to-end handshake (Task A2.1).
+
+Bypasses the LLM subagents: loads a hand-written Tier-1 DSL config and
+invokes Lin's Runner directly. The point is to prove the orchestration
+↔ Runner contract works before any Ideator/Coder are wired in.
+
+Use
+---
+
+    python scripts/e2e_handshake.py --round-dir runs/handshake/round_0
+
+The script is intentionally small — anything more than `load env → build
+config → run_round → print metrics` belongs in the research loop, not here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+from autoqec.envs.schema import load_env_yaml
+from autoqec.runner.schema import RunnerConfig
+
+DEFAULT_ENV_YAML = "autoqec/envs/builtin/surface_d5_depol.yaml"
+DEFAULT_STUB_YAML = "autoqec/example_db/handshake_stub.yaml"
+
+
+def build_runner_config(
+    env_yaml: str | Path,
+    stub_yaml: str | Path,
+    round_dir: str | Path,
+    seed: int = 0,
+) -> RunnerConfig:
+    """Load env + DSL stub and compose a RunnerConfig matching §2.2.
+
+    Kept importable so the unit test can exercise the config-composition
+    contract without touching torch.
+    """
+    env = load_env_yaml(env_yaml)
+    cfg_dict = yaml.safe_load(Path(stub_yaml).read_text(encoding="utf-8"))
+    return RunnerConfig(
+        env_name=env.name,
+        predecoder_config=cfg_dict,
+        training_profile=cfg_dict.get("training", {}).get("profile", "dev"),
+        seed=seed,
+        round_dir=str(Path(round_dir).resolve()),
+    )
+
+
+def main(
+    env_yaml: str | Path = DEFAULT_ENV_YAML,
+    stub_yaml: str | Path = DEFAULT_STUB_YAML,
+    round_dir: str | Path = "runs/handshake/round_0",
+    seed: int = 0,
+) -> dict:
+    """Run one Runner round and return the metrics dict.
+
+    Imports the heavy Runner lazily so importing this module for unit
+    tests does not require torch.
+    """
+    from autoqec.runner.runner import run_round  # noqa: PLC0415 — intentional lazy import
+
+    env = load_env_yaml(env_yaml)
+    cfg = build_runner_config(env_yaml, stub_yaml, round_dir, seed)
+    metrics = run_round(cfg, env)
+    print(metrics.model_dump_json(indent=2))
+    return json.loads(metrics.model_dump_json())
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env-yaml", default=DEFAULT_ENV_YAML)
+    p.add_argument("--stub-yaml", default=DEFAULT_STUB_YAML)
+    p.add_argument("--round-dir", default="runs/handshake/round_0")
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    main(
+        env_yaml=args.env_yaml,
+        stub_yaml=args.stub_yaml,
+        round_dir=args.round_dir,
+        seed=args.seed,
+    )

--- a/scripts/run_single_round.py
+++ b/scripts/run_single_round.py
@@ -31,8 +31,10 @@ from autoqec.envs.schema import load_env_yaml  # noqa: E402
 from autoqec.orchestration.loop import run_round_plan  # noqa: E402
 from autoqec.tools.machine_state import machine_state  # noqa: E402
 
-KB_PATH = Path("knowledge/DECODER_ROADMAP.md")
-SPEC_PATH = Path("docs/superpowers/specs/2026-04-20-autoqec-design.md")
+# Anchor knowledge excerpts to the repo root so running from a foreign
+# cwd doesn't silently drop them from the Ideator prompt (Codex review).
+KB_PATH = _REPO_ROOT / "knowledge/DECODER_ROADMAP.md"
+SPEC_PATH = _REPO_ROOT / "docs/superpowers/specs/2026-04-20-autoqec-design.md"
 KB_EXCERPT_MAX_CHARS = 3000
 
 

--- a/scripts/run_single_round.py
+++ b/scripts/run_single_round.py
@@ -1,0 +1,89 @@
+"""Single-round driver (Task A2.2).
+
+Assembles the L3 context for one research round and emits the Ideator
+prompt + bookkeeping paths as JSON. The caller (inline `Agent` tool or a
+future subprocess router) fills in the Ideator/Coder/Analyst responses.
+
+This script does NOT invoke any LLM itself. Day-3 will add the wrapper
+that chains responses through the Runner.
+
+Use
+---
+
+    python scripts/run_single_round.py \\
+        --env-yaml autoqec/envs/builtin/surface_d5_depol.yaml \\
+        --run-dir runs/demo-1 --round-idx 1 [--budget-s 3600]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Make the repo root importable when the script is run directly
+# (e.g. `python scripts/run_single_round.py ...`) without `pip install -e .`.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from autoqec.envs.schema import load_env_yaml  # noqa: E402
+from autoqec.orchestration.loop import run_round_plan  # noqa: E402
+from autoqec.tools.machine_state import machine_state  # noqa: E402
+
+KB_PATH = Path("knowledge/DECODER_ROADMAP.md")
+SPEC_PATH = Path("docs/superpowers/specs/2026-04-20-autoqec-design.md")
+KB_EXCERPT_MAX_CHARS = 3000
+
+
+def _read_text_best_effort(path: Path, max_chars: int | None = None) -> str:
+    if not path.exists():
+        return ""
+    text = path.read_text(encoding="utf-8")
+    return text[:max_chars] if max_chars else text
+
+
+def plan_for_round(
+    env_yaml: str | Path,
+    run_dir: str | Path,
+    round_idx: int,
+    budget_s: float | None = None,
+) -> dict:
+    env = load_env_yaml(env_yaml)
+    run_dir = Path(run_dir)
+    ms = machine_state(run_dir, total_wallclock_s_budget=budget_s)
+    kb = _read_text_best_effort(KB_PATH, KB_EXCERPT_MAX_CHARS)
+    dsl_md = _read_text_best_effort(SPEC_PATH)
+    return run_round_plan(
+        env_spec=env,
+        run_dir=run_dir,
+        round_idx=round_idx,
+        machine_state=ms,
+        kb_excerpt=kb,
+        dsl_schema_md=dsl_md,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env-yaml", required=True)
+    p.add_argument("--run-dir", required=True)
+    p.add_argument("--round-idx", type=int, required=True)
+    p.add_argument("--budget-s", type=float, default=None, help="outer wall-clock budget in seconds")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    plan = plan_for_round(
+        env_yaml=args.env_yaml,
+        run_dir=args.run_dir,
+        round_idx=args.round_idx,
+        budget_s=args.budget_s,
+    )
+    sys.stdout.write(json.dumps(plan, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_e2e_handshake.py
+++ b/tests/test_e2e_handshake.py
@@ -53,3 +53,21 @@ def test_handshake_script_main_runs_e2e(tmp_path: Path) -> None:
     assert result["status"] == "ok"
     metrics_path = tmp_path / "round_0" / "metrics.json"
     assert metrics_path.exists()
+
+
+def test_build_runner_config_works_from_foreign_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Codex review (medium): handshake must work from any cwd, not only repo root."""
+    import os
+
+    from scripts.e2e_handshake import build_runner_config
+
+    monkeypatch.chdir(tmp_path)  # foreign cwd — repo paths must still resolve
+    cfg = build_runner_config(
+        env_yaml=None,
+        stub_yaml=None,
+        round_dir=tmp_path / "round_0",
+    )
+    assert cfg.env_name == "surface_d5_depol"
+    assert cfg.predecoder_config["type"] == "gnn"
+    # sanity: cwd is not the repo root
+    assert Path(os.getcwd()) != Path(__file__).resolve().parents[1]

--- a/tests/test_e2e_handshake.py
+++ b/tests/test_e2e_handshake.py
@@ -1,0 +1,55 @@
+"""Tests for scripts.e2e_handshake (Task A2.1).
+
+The end-to-end training run is marked `integration` because it needs torch
++ stim + pymatching installed. The contract checks (config loads, env
+loads, RunnerConfig builds) are unit tests and run in CI without GPU.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_handshake_stub_yaml_validates_against_predecoder_dsl() -> None:
+    """If the stub drifts from PredecoderDSL, every future handshake run
+    will fail at `compile_predecoder` time — catch it at unit-test time."""
+    import yaml
+
+    from autoqec.decoders.dsl_schema import PredecoderDSL
+
+    data = yaml.safe_load(
+        Path("autoqec/example_db/handshake_stub.yaml").read_text(encoding="utf-8")
+    )
+    PredecoderDSL(**data)  # raises on schema drift
+
+
+def test_build_runner_config_composes_env_and_stub(tmp_path: Path) -> None:
+    """Contract between orchestration and Runner: RunnerConfig fields line
+    up with what Lin's run_round expects."""
+    from scripts.e2e_handshake import build_runner_config
+
+    cfg = build_runner_config(
+        env_yaml="autoqec/envs/builtin/surface_d5_depol.yaml",
+        stub_yaml="autoqec/example_db/handshake_stub.yaml",
+        round_dir=tmp_path / "round_0",
+        seed=7,
+    )
+    assert cfg.env_name == "surface_d5_depol"
+    assert cfg.training_profile == "dev"
+    assert cfg.seed == 7
+    assert Path(cfg.round_dir).is_absolute()
+    # predecoder_config was parsed as a plain dict (Runner expects dict, not pydantic)
+    assert cfg.predecoder_config["type"] == "gnn"
+    assert cfg.predecoder_config["gnn"]["hidden_dim"] == 16
+
+
+@pytest.mark.integration
+def test_handshake_script_main_runs_e2e(tmp_path: Path) -> None:
+    """Actually runs one dev-profile round. Requires torch + stim + pymatching."""
+    from scripts.e2e_handshake import main
+
+    result = main(round_dir=tmp_path / "round_0", seed=0)
+    assert result["status"] == "ok"
+    metrics_path = tmp_path / "round_0" / "metrics.json"
+    assert metrics_path.exists()

--- a/tests/test_machine_state.py
+++ b/tests/test_machine_state.py
@@ -1,0 +1,68 @@
+"""Unit tests for autoqec.tools.machine_state (Task A2.2).
+
+GPU probing is covered by a separate integration test; these tests
+exercise the history-derived branches without torch.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write_history(run_dir: Path, rounds: list[dict]) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    with (run_dir / "history.jsonl").open("w", encoding="utf-8") as f:
+        for record in rounds:
+            f.write(json.dumps(record) + "\n")
+
+
+def test_machine_state_empty_history(tmp_path: Path) -> None:
+    from autoqec.tools.machine_state import machine_state
+
+    state = machine_state(tmp_path / "empty")
+    assert state["history_timings"]["rounds_so_far"] == 0
+    assert state["history_timings"]["wall_clock_mean_s"] == 0
+    assert state["history_timings"]["wall_clock_p95_s"] == 0
+    assert state["history_timings"]["killed_by_safety_count"] == 0
+    assert state["budget"]["total_wallclock_s_spent"] == 0
+
+
+def test_machine_state_aggregates_timings_and_killed_count(tmp_path: Path) -> None:
+    from autoqec.tools.machine_state import machine_state
+
+    _write_history(
+        tmp_path / "run",
+        rounds=[
+            {"round": 1, "status": "ok", "train_wallclock_s": 10.0, "eval_wallclock_s": 2.0, "n_params": 5000},
+            {"round": 2, "status": "killed_by_safety", "train_wallclock_s": 3.0, "eval_wallclock_s": 0.0, "n_params": 50000},
+            {"round": 3, "status": "ok", "train_wallclock_s": 20.0, "eval_wallclock_s": 5.0, "n_params": 8000},
+        ],
+    )
+    state = machine_state(tmp_path / "run")
+    timings = state["history_timings"]
+    assert timings["rounds_so_far"] == 3
+    assert timings["killed_by_safety_count"] == 1
+    # (10+2) + (3+0) + (20+5) = 40; mean = 40/3
+    assert timings["wall_clock_mean_s"] == 40 / 3
+    # p95 index: int(0.95 * 3) == 2 → max of sorted = 25
+    assert timings["wall_clock_p95_s"] == 25.0
+    assert timings["params_vs_time"] == [(5000, 12.0), (50000, 3.0), (8000, 25.0)]
+    assert state["budget"]["total_wallclock_s_spent"] == 40.0
+    assert state["budget"]["total_wallclock_s_remaining"] is None
+
+
+def test_machine_state_accepts_budget_remaining_override(tmp_path: Path) -> None:
+    """Callers (the orchestrator) plug in the outer time budget."""
+    from autoqec.tools.machine_state import machine_state
+
+    state = machine_state(tmp_path / "new", total_wallclock_s_budget=3600)
+    assert state["budget"]["total_wallclock_s_remaining"] == 3600
+
+
+def test_machine_state_gpu_section_is_present_even_without_cuda(tmp_path: Path) -> None:
+    """When torch is missing or CUDA is unavailable, gpu is {} (not absent)."""
+    from autoqec.tools.machine_state import machine_state
+
+    state = machine_state(tmp_path / "gpuless")
+    assert "gpu" in state
+    assert isinstance(state["gpu"], dict)

--- a/tests/test_machine_state.py
+++ b/tests/test_machine_state.py
@@ -66,3 +66,25 @@ def test_machine_state_gpu_section_is_present_even_without_cuda(tmp_path: Path) 
     state = machine_state(tmp_path / "gpuless")
     assert "gpu" in state
     assert isinstance(state["gpu"], dict)
+
+
+def test_gpu_snapshot_swallows_driver_errors_from_is_available(monkeypatch) -> None:
+    """Codex review (medium): the docstring promises *any* failure returns {};
+    the original code only guarded `import torch`, so `is_available()` raising
+    (e.g. driver init error) would crash plan assembly."""
+    import sys
+    import types
+
+    fake_torch = types.ModuleType("torch")
+
+    class _FakeCuda:
+        @staticmethod
+        def is_available() -> bool:
+            raise RuntimeError("simulated driver failure")
+
+    fake_torch.cuda = _FakeCuda()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    from autoqec.tools.machine_state import _gpu_snapshot
+
+    assert _gpu_snapshot() == {}

--- a/tests/test_run_single_round.py
+++ b/tests/test_run_single_round.py
@@ -1,0 +1,47 @@
+"""Unit tests for scripts.run_single_round (Task A2.2)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_plan_for_round_returns_round_dir_and_prompt(tmp_path: Path) -> None:
+    from scripts.run_single_round import plan_for_round
+
+    plan = plan_for_round(
+        env_yaml="autoqec/envs/builtin/surface_d5_depol.yaml",
+        run_dir=tmp_path / "run",
+        round_idx=3,
+        budget_s=3600,
+    )
+    assert plan["round_idx"] == 3
+    assert plan["round_dir"].endswith("round_3")
+    assert "IDEATOR" in plan["ideator_prompt"]
+    # machine_state's budget should reach the prompt
+    assert "budget" in plan["ideator_prompt"]
+
+
+def test_run_single_round_cli_prints_valid_json(tmp_path: Path) -> None:
+    """End-to-end shell-level contract: prints a JSON object to stdout."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_single_round.py",
+            "--env-yaml",
+            "autoqec/envs/builtin/surface_d5_depol.yaml",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--round-idx",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding="utf-8",
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["round_idx"] == 1
+    assert payload["round_dir"].endswith("round_1")
+    assert "IDEATOR" in payload["ideator_prompt"]

--- a/tests/test_run_single_round.py
+++ b/tests/test_run_single_round.py
@@ -45,3 +45,35 @@ def test_run_single_round_cli_prints_valid_json(tmp_path: Path) -> None:
     assert payload["round_idx"] == 1
     assert payload["round_dir"].endswith("round_1")
     assert "IDEATOR" in payload["ideator_prompt"]
+
+
+def test_kb_and_spec_excerpts_reach_ideator_prompt_from_foreign_cwd(tmp_path: Path) -> None:
+    """Codex review (medium): KB/SPEC paths must be anchored to the repo root,
+    not the caller's cwd. Without the fix, running from outside the repo
+    silently yields an empty knowledge excerpt."""
+    repo_root = Path(__file__).resolve().parents[1]
+    env_abs = str(repo_root / "autoqec/envs/builtin/surface_d5_depol.yaml")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts/run_single_round.py"),
+            "--env-yaml",
+            env_abs,
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--round-idx",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding="utf-8",
+        cwd=tmp_path,  # foreign cwd
+    )
+    payload = json.loads(completed.stdout)
+    # DECODER_ROADMAP snippet should now be embedded in the Ideator prompt.
+    # Signature: the roadmap has a top-level "Decoder" heading — any substring from it works.
+    assert "knowledge_excerpts" in payload["ideator_prompt"]
+    # and the spec dsl excerpt: the frozen spec title contains "AutoQEC"
+    assert "AutoQEC" in payload["ideator_prompt"]


### PR DESCRIPTION
Day-2 follow-up to [PR #4](https://github.com/qualit527/qec-ai-decoder/pull/4) (Day-1, already merged).

## Summary

Chen Jiahan's Phase-2 slice from `docs/superpowers/plans/2026-04-21-autoqec-person-a-chen.md`:

- **A2.1** `scripts/e2e_handshake.py` + `autoqec/example_db/handshake_stub.yaml` — no-LLM handshake that drives Lin's `run_round` with a Tier-1 GNN config. Proves orchestration ↔ Runner before Ideator/Coder wiring. `build_runner_config()` is importable, so unit tests exercise the config-composition contract without torch; the live training path is marked `@pytest.mark.integration`.
- **A2.2** `autoqec/tools/machine_state.py` + `scripts/run_single_round.py` — `machine_state(run_dir, total_wallclock_s_budget=...)` returns the Ideator's `machine_state_hint` (gpu / history timings / budget). Lazy torch import + broad exception guard keep the probe importable even when CUDA drivers are flaky. `run_single_round.py` is a torch-free CLI that assembles the L3 Ideator context and prints the prompt + round dir as JSON.
- **Round-dir layout contract** `docs/contracts/round_dir_layout.md` — one-page spec of who writes what inside `runs/<run_id>/round_<N>/`: Runner writes `config.yaml`, `train.log`, `checkpoint.pt`, `metrics.json`; orchestration writes `history.jsonl`, `log.md`, `pareto.json` at the run root. Invariants split into Enforced now vs `[TODO-fill-in]` with named owner.

## Codex review applied (commit `1e34ea0`)

GPT-5.4 via Codex MCP reviewed the initial 3 Day-2 commits and flagged 4 medium findings + 2 open questions; all closed:

- **MED** `scripts/e2e_handshake.py` lacked the `_REPO_ROOT` sys.path bootstrap + cwd-relative default YAMLs. Now mirrors `run_single_round.py`; works from any cwd. New foreign-cwd test.
- **MED** `scripts/run_single_round.py` had cwd-relative `KB_PATH` / `SPEC_PATH` — silently dropped the Ideator's knowledge context when invoked outside repo root. Anchored to `_REPO_ROOT`. New subprocess test verifies the spec excerpt reaches the Ideator prompt.
- **MED** `autoqec/tools/machine_state._gpu_snapshot` guarded only `import torch`, leaking `torch.cuda.is_available()` driver errors. Wrapped the entire probe in one `try/except Exception`. New test monkeypatches `is_available` to raise.
- **MED** `docs/contracts/round_dir_layout.md` overclaimed: removed the `train.log → params_vs_time` misstatement; scoped the UTF-8 and absolute-path invariants to orchestration-side (Runner-side opened as `[TODO-fill-in, Lin]`); split invariants into Enforced now vs aspirational.

## Test plan

- [x] `pytest tests/test_e2e_handshake.py tests/test_machine_state.py tests/test_run_single_round.py -v` — 11 pass + 1 `integration` skipped
- [x] `pytest tests/test_orchestration_stub.py tests/test_surface_baseline_benchmark.py tests/test_pymatching_baseline.py tests/test_surface_assets.py tests/test_dsl_schema.py` — 23 pass (regression check)
- [x] `ruff check` on all new/edited files — clean
- [ ] Live A2.1 handshake run (needs torch-enabled env) — integration test is ready to flip once CI has torch installed

## Not in this PR (Day-3)

- A3.1 `/autoqec-run` SKILL.md
- A3.2 `/add-env` SKILL.md (CLI already on main)
- A3.3 Demo 1 README + run.sh + walkthrough
- A3.4 Execute Demo 1 smoke run + capture output

## Gap flagged for Lin Tengxiang

`docs/contracts/round_dir_layout.md` calls out two `[TODO-fill-in, Lin]` items that belong to the Runner subtree:

1. `cli/autoqec.py::run` passes a cwd-relative `round_dir` into `RunnerConfig` → `metrics.json`'s `checkpoint_path` / `training_log_path` inherit that. One `.resolve()` before passing makes every writer produce absolute paths.
2. `autoqec/runner/runner.py:61, 163, 230` open text files without explicit `encoding="utf-8"`. Low-risk 3-line fix; brings Runner-side files in line with the orchestration-side UTF-8 invariant.

Both are small, uncontroversial tightenings — happy to send a follow-up PR against his subtree if he'd prefer not to do them himself.

## Summary by Sourcery

Define the round/run directory layout contract and add tooling and scripts to support an LLM-free handshake and single-round orchestration planning.

New Features:
- Add an e2e handshake script and minimal GNN YAML stub to run a single Runner round without LLM subagents and verify the Runner contract.
- Introduce a machine_state probe that summarizes GPU info, past round timings, and wall-clock budget for use as Ideator context.
- Provide a run_single_round CLI that assembles L3 Ideator context, including env spec, machine state, and knowledge/spec excerpts, and emits a JSON plan for one round.

Bug Fixes:
- Ensure the handshake and single-round scripts resolve repo-relative files and knowledge/spec paths from the repository root so they work correctly from any current working directory.
- Harden the GPU probing helper so CUDA/driver failures during torch checks no longer crash orchestration and instead yield an empty GPU snapshot.

Enhancements:
- Document and freeze the round and run directory layout, ownership, and invariants in a dedicated contract, including current guarantees and TODOs for future tightening.

Tests:
- Add unit and subprocess tests for the handshake script, machine_state probe, and run_single_round CLI, including foreign-cwd and GPU driver failure scenarios.