### PR TITLE
ci: add phase-1 GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install project and dev dependencies
+        run: python -m pip install -e '.[dev]'
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run non-integration tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Create virtualenv
+        run: python -m venv .venv
+
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: ./.venv/bin/python -m pip install --upgrade pip
 
       - name: Install project and dev dependencies
-        run: python -m pip install -e '.[dev]'
+        run: ./.venv/bin/python -m pip install -e '.[dev]'
 
       - name: Run lint
         run: make lint

--- a/docs/superpowers/plans/2026-04-22-ci-phase-1.md
+++ b/docs/superpowers/plans/2026-04-22-ci-phase-1.md
@@ -1,0 +1,101 @@
+# Phase-1 CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimal GitHub Actions CI workflow that runs lint and non-integration tests on every push and pull request.
+
+**Architecture:** The implementation uses a single GitHub Actions workflow with one `lint-and-test` job on `ubuntu-latest`. It sets up Python 3.12, installs the project with dev dependencies, then reuses the repository's existing `Makefile` entry points so local and CI behavior stay aligned.
+
+**Tech Stack:** GitHub Actions, Python 3.12, pip, Make, Ruff, pytest
+
+---
+
+### Task 1: Add CI workflow
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Write `.github/workflows/ci.yml` with this content:
+
+```yaml
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install project and dev dependencies
+        run: python -m pip install -e '.[dev]'
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run non-integration tests
+        run: make test
+```
+
+- [ ] **Step 2: Inspect the workflow file**
+
+Run: `sed -n '1,240p' .github/workflows/ci.yml`
+
+Expected: the workflow contains `push`, `pull_request`, `python-version: "3.12"`, `make lint`, and `make test`.
+
+### Task 2: Verify the repository commands used by CI
+
+**Files:**
+- Verify: `Makefile`
+- Verify: `pyproject.toml`
+
+- [ ] **Step 1: Verify lint command exists**
+
+Run: `make lint`
+
+Expected: Ruff runs and exits successfully.
+
+- [ ] **Step 2: Verify non-integration test command exists**
+
+Run: `make test`
+
+Expected: pytest runs `tests/ -m "not integration" -v` and exits successfully.
+
+### Task 3: Commit the CI workflow
+
+**Files:**
+- Commit: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Check git status**
+
+Run: `git status --short`
+
+Expected: `.github/workflows/ci.yml` appears as a new tracked file, with no unexpected edits required for this task.
+
+- [ ] **Step 2: Commit the workflow**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add phase-1 GitHub Actions workflow"
+```
+
+- [ ] **Step 3: Confirm the commit**
+
+Run: `git show --stat --oneline HEAD`
+
+Expected: the latest commit message is `ci: add phase-1 GitHub Actions workflow` and the diff includes `.github/workflows/ci.yml`.

--- a/docs/superpowers/specs/2026-04-22-ci-design.md
+++ b/docs/superpowers/specs/2026-04-22-ci-design.md
@@ -1,0 +1,122 @@
+# CI Design (Phase 1)
+
+## Goal
+
+Add a minimal GitHub Actions CI pipeline that blocks broken pull requests early.
+The first version should only verify code quality and basic repository health:
+
+- install the project with dev dependencies
+- run lint
+- run non-integration tests
+
+This CI is intentionally narrow. It is not responsible for long-running research jobs, demo scripts, LLM-backed workflows, or release automation.
+
+## Scope
+
+### In scope
+
+- one workflow file at `.github/workflows/ci.yml`
+- triggers on `push` and `pull_request`
+- Python 3.12 runner setup
+- dependency installation via `pip install -e '.[dev]'`
+- lint via `make lint`
+- tests via `make test`
+
+### Out of scope
+
+- integration tests
+- demo runs such as `demo-2`
+- any workflow that requires API keys or model backends
+- packaging or release publishing
+- matrix testing across multiple Python versions
+
+## Current Repository Constraints
+
+The repository already provides stable entry points for a first CI pass:
+
+- `make lint` runs `ruff check autoqec cli tests scripts`
+- `make test` runs `pytest tests/ -m "not integration" -v`
+- `pyproject.toml` requires Python `>=3.12`
+
+These commands should remain the source of truth for CI so local development and GitHub Actions stay aligned.
+
+## Proposed Approach
+
+Use a single workflow with a single job named `lint-and-test`.
+
+Why this approach:
+
+- simplest possible starting point
+- easiest to debug when CI first lands
+- keeps repository conventions centralized in `Makefile`
+- avoids premature job splitting before runtime becomes a problem
+
+## Workflow Design
+
+### Trigger policy
+
+The workflow should run on:
+
+- every pull request
+- every push
+
+This gives immediate feedback on feature branches and also protects direct pushes.
+
+### Execution environment
+
+- runner: `ubuntu-latest`
+- Python version: `3.12`
+
+### Job steps
+
+1. Check out the repository.
+2. Set up Python 3.12.
+3. Upgrade `pip`.
+4. Install the package with dev dependencies:
+   `python -m pip install -e '.[dev]'`
+5. Run lint:
+   `make lint`
+6. Run non-integration tests:
+   `make test`
+
+## Failure Model
+
+The workflow should fail immediately when:
+
+- dependency installation fails
+- lint finds violations
+- any non-integration test fails
+
+This is the intended branch gate behavior.
+
+## Design Choices
+
+### Why not run integration tests now
+
+Integration tests are explicitly separated in the repository using the `integration` marker. Keeping them out of Phase-1 CI avoids turning every PR into a slower and more fragile pipeline.
+
+### Why not run demos now
+
+Demo scripts are closer to project validation and showcase workflows than to basic branch gating. They are a better fit for a later manual or scheduled workflow.
+
+### Why not add caching yet
+
+Dependency caching can be added later if CI runtime becomes a real problem. For the first iteration, fewer moving parts is more important than optimization.
+
+## Expected Outcome
+
+After this workflow lands:
+
+- every PR gets automatic lint and test feedback
+- broken branches are caught before merge
+- local commands and CI commands remain identical
+- the repository has a clean foundation for later `integration.yml` and `release.yml`
+
+## Future Extensions
+
+Likely next steps after Phase 1:
+
+1. add a separate manually triggered or main-branch-only integration workflow
+2. add branch protection requiring the CI check to pass before merge
+3. add release automation for tags
+4. optionally split lint and test into separate jobs if runtime grows

--- a/docs/superpowers/specs/2026-04-22-ci-design.md
+++ b/docs/superpowers/specs/2026-04-22-ci-design.md
@@ -18,7 +18,8 @@ This CI is intentionally narrow. It is not responsible for long-running research
 - one workflow file at `.github/workflows/ci.yml`
 - triggers on `push` and `pull_request`
 - Python 3.12 runner setup
-- dependency installation via `pip install -e '.[dev]'`
+- creation of a repo-local `.venv`
+- dependency installation into `.venv`
 - lint via `make lint`
 - tests via `make test`
 
@@ -72,11 +73,14 @@ This gives immediate feedback on feature branches and also protects direct pushe
 1. Check out the repository.
 2. Set up Python 3.12.
 3. Upgrade `pip`.
-4. Install the package with dev dependencies:
-   `python -m pip install -e '.[dev]'`
-5. Run lint:
+4. Create a repo-local virtual environment:
+   `python -m venv .venv`
+5. Upgrade `pip` inside the virtual environment.
+6. Install the package with dev dependencies into the virtual environment:
+   `./.venv/bin/python -m pip install -e '.[dev]'`
+7. Run lint:
    `make lint`
-6. Run non-integration tests:
+8. Run non-integration tests:
    `make test`
 
 ## Failure Model
@@ -102,6 +106,10 @@ Demo scripts are closer to project validation and showcase workflows than to bas
 ### Why not add caching yet
 
 Dependency caching can be added later if CI runtime becomes a real problem. For the first iteration, fewer moving parts is more important than optimization.
+
+### Why create `.venv` in CI
+
+The repository `Makefile` calls tools from `./.venv/bin/...`. Creating `.venv` inside GitHub Actions keeps CI behavior aligned with local development instead of depending on globally installed runner tools.
 
 ## Expected Outcome
 


### PR DESCRIPTION
## Summary
- add a Phase-1 GitHub Actions CI workflow for `push` and `pull_request`
- run `python -m pip install -e '.[dev]'`, `make lint`, and `make test` in CI
- include the approved CI design and execution plan documents for project traceability

## Test Plan
- [x] `make lint`
- [x] `make test`

## Summary by Sourcery

Add an initial GitHub Actions CI workflow that runs linting and non-integration tests on pushes and pull requests, and document the CI design and implementation plan for traceability.

CI:
- Introduce a phase-1 GitHub Actions workflow that installs dev dependencies, runs make lint, and executes non-integration tests via make test on push and pull_request events.

Documentation:
- Add CI design and phase-1 implementation plan documents describing the workflow scope, behavior, and future extensions.