### PR TITLE
fix: close §15 audit findings (H1/H2 + M1-M3)

### DIFF
--- a/autoqec/decoders/custom_fn_rules.py
+++ b/autoqec/decoders/custom_fn_rules.py
@@ -13,7 +13,41 @@ ALLOWED_FROM_IMPORTS: frozenset[str] = frozenset(
     {"torch", "torch.nn", "torch.nn.functional", "typing"}
 )
 FORBIDDEN_NAMES: frozenset[str] = frozenset(
-    {"os", "subprocess", "sys", "shutil", "socket", "urllib", "eval", "exec", "open"}
+    {
+        # process / filesystem / network escape modules
+        "os",
+        "subprocess",
+        "sys",
+        "shutil",
+        "socket",
+        "urllib",
+        "pathlib",
+        "io",
+        "tempfile",
+        "pickle",
+        "marshal",
+        "ctypes",
+        "importlib",
+        # builtin escape hatches — names must not appear bare even though
+        # the validator also shadows __builtins__ at exec time.
+        "eval",
+        "exec",
+        "open",
+        "compile",
+        "input",
+        "breakpoint",
+        "help",
+        "__import__",
+        "__builtins__",
+        # reflective builtins that can reach out to __class__ / globals etc.
+        "getattr",
+        "setattr",
+        "delattr",
+        "vars",
+        "globals",
+        "locals",
+        "dir",
+    }
 )
 SLOT_SIGNATURES: dict[str, list[str]] = {
     "message_fn": ["x_src", "x_dst", "e_ij", "params"],

--- a/autoqec/decoders/custom_fn_validator.py
+++ b/autoqec/decoders/custom_fn_validator.py
@@ -1,10 +1,27 @@
+"""AST + smoke-test validator for Tier-2 ``custom_fn`` predecoder blocks.
+
+Two-stage gate:
+
+1. Parse the source with ``ast`` and enforce structural rules:
+   - exactly one function definition at module level
+   - signature matches the slot's expected argument names
+   - imports restricted to ``ALLOWED_TOP_IMPORTS`` / ``ALLOWED_FROM_IMPORTS``
+   - no ``FORBIDDEN_NAMES`` references (``os``, ``eval``, builtins-level
+     escape hatches such as ``__import__``, ``getattr``, ``__builtins__``, ...)
+   - no attribute access to dunder names (blocks ``x.__class__.__mro__``)
+     or leading-underscore private slots
+2. ``exec`` the source with a *restricted* ``__builtins__`` so even if the
+   AST check missed something, calls like ``open(...)`` / ``__import__(...)``
+   are unresolvable at runtime.
+
+Torch-heavy imports are loaded lazily so the validator module stays cheap
+to import from tests / orchestration layers that just need the rule set.
+"""
 from __future__ import annotations
 
 import ast
-from types import FunctionType
-
-import torch
-from torch import nn
+from types import FunctionType, MappingProxyType
+from typing import Any, Mapping
 
 from autoqec.decoders.custom_fn_rules import (
     ALLOWED_FROM_IMPORTS,
@@ -18,13 +35,98 @@ __all__ = [
     "ALLOWED_FROM_IMPORTS",
     "FORBIDDEN_NAMES",
     "SLOT_SIGNATURES",
+    "SAFE_BUILTINS",
     "validate_custom_fn",
 ]
 
 
+# Minimal builtins we expose to Tier-2 user code. Anything not listed here
+# resolves to ``NameError`` at call time — a last-mile defense if a static
+# check misses a new escape pattern. Keep this set as small as we can
+# justify; the Coder subagent's prompt enumerates the public surface it can
+# rely on.
+_SAFE_BUILTIN_NAMES: frozenset[str] = frozenset(
+    {
+        # construction / iteration
+        "bool",
+        "int",
+        "float",
+        "complex",
+        "str",
+        "bytes",
+        "tuple",
+        "list",
+        "dict",
+        "set",
+        "frozenset",
+        "range",
+        "enumerate",
+        "zip",
+        "iter",
+        "next",
+        "reversed",
+        "sorted",
+        "filter",
+        "map",
+        # type checks
+        "isinstance",
+        "issubclass",
+        # math / stats
+        "abs",
+        "min",
+        "max",
+        "sum",
+        "round",
+        "pow",
+        "len",
+        "any",
+        "all",
+        "divmod",
+        # misc pure helpers
+        "slice",
+        "id",
+        # exceptions the user might catch inside their function
+        "Exception",
+        "ValueError",
+        "TypeError",
+        "RuntimeError",
+        "ZeroDivisionError",
+        "IndexError",
+        "KeyError",
+        "AttributeError",
+        "NotImplementedError",
+    }
+)
+
+
+def _build_safe_builtins() -> Mapping[str, Any]:
+    import builtins as _builtins
+
+    allowed = {
+        name: getattr(_builtins, name)
+        for name in _SAFE_BUILTIN_NAMES
+        if hasattr(_builtins, name)
+    }
+    return MappingProxyType(allowed)
+
+
+SAFE_BUILTINS: Mapping[str, Any] = _build_safe_builtins()
+
+
 def _load_function(code: str) -> FunctionType:
-    namespace: dict[str, object] = {"torch": torch}
-    exec(compile(code, "<custom_fn>", "exec"), namespace, namespace)
+    # Lazy import torch so the validator module itself stays torch-free;
+    # smoke tests still run the function against real tensors below.
+    import torch
+
+    # Restricted exec namespace. We deliberately shadow ``__builtins__`` with
+    # our allow-list instead of the real module — a Tier-2 function that
+    # tries ``__import__('os')`` or ``open('/etc/passwd')`` now raises
+    # NameError at evaluation time, not just a lint rejection.
+    namespace: dict[str, object] = {
+        "__builtins__": dict(SAFE_BUILTINS),
+        "torch": torch,
+    }
+    exec(compile(code, "<custom_fn>", "exec"), namespace, namespace)  # noqa: S102 - sandboxed
     funcs = [value for value in namespace.values() if isinstance(value, FunctionType)]
     if len(funcs) != 1:
         raise ValueError("Must define exactly one function")
@@ -32,6 +134,9 @@ def _load_function(code: str) -> FunctionType:
 
 
 def _smoke_test(fn: FunctionType, slot: str) -> tuple[bool, str]:
+    import torch
+    from torch import nn
+
     try:
         if slot == "message_fn":
             params = {
@@ -58,23 +163,8 @@ def _smoke_test(fn: FunctionType, slot: str) -> tuple[bool, str]:
     return True, "ok"
 
 
-def validate_custom_fn(code: str, slot: str) -> tuple[bool, str]:
-    try:
-        tree = ast.parse(code)
-    except SyntaxError as exc:
-        return False, f"SyntaxError: {exc}"
-
-    functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
-    if len(functions) != 1:
-        return False, "Must define exactly one function"
-
-    expected = SLOT_SIGNATURES.get(slot)
-    if expected is None:
-        return False, f"Unknown slot: {slot}"
-    actual = [arg.arg for arg in functions[0].args.args]
-    if actual != expected:
-        return False, f"Signature must be {expected}, got {actual}"
-
+def _static_ast_checks(tree: ast.AST) -> tuple[bool, str]:
+    """Pure-AST rejection pass. No code execution, no torch required."""
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -92,10 +182,38 @@ def validate_custom_fn(code: str, slot: str) -> tuple[bool, str]:
                 return False, f"From-import not in whitelist: {module}"
         elif isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
             return False, f"Forbidden name reference: {node.id}"
+        elif isinstance(node, ast.Attribute):
+            # Block dunder / private attribute access — closes the classic
+            # sandbox escape via ``().__class__.__mro__[1].__subclasses__()``
+            # and ``x.__globals__`` / ``fn.__code__`` style poking.
+            if node.attr.startswith("_"):
+                return False, f"Forbidden attribute access: .{node.attr}"
+    return True, "ok"
+
+
+def validate_custom_fn(code: str, slot: str) -> tuple[bool, str]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        return False, f"SyntaxError: {exc}"
+
+    functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
+    if len(functions) != 1:
+        return False, "Must define exactly one function"
+
+    expected = SLOT_SIGNATURES.get(slot)
+    if expected is None:
+        return False, f"Unknown slot: {slot}"
+    actual = [arg.arg for arg in functions[0].args.args]
+    if actual != expected:
+        return False, f"Signature must be {expected}, got {actual}"
+
+    ok, reason = _static_ast_checks(tree)
+    if not ok:
+        return False, reason
 
     try:
         fn = _load_function(code)
     except Exception as exc:
         return False, f"Compilation failed: {exc}"
     return _smoke_test(fn, slot)
-

--- a/autoqec/decoders/custom_fn_validator.py
+++ b/autoqec/decoders/custom_fn_validator.py
@@ -107,6 +107,14 @@ def _build_safe_builtins() -> Mapping[str, Any]:
         for name in _SAFE_BUILTIN_NAMES
         if hasattr(_builtins, name)
     }
+    # Python's ``import`` statement compiles to a call to ``__import__`` at
+    # runtime, so exec-time user code like ``import torch`` needs the name
+    # present in builtins to work. We still reject *bare* ``__import__``
+    # references via ``FORBIDDEN_NAMES`` in the AST pass, and imports
+    # themselves go through the ``ALLOWED_TOP_IMPORTS`` whitelist — so the
+    # dynamic escape ``__import__('os')`` / ``__import__('torch')`` cannot
+    # reach here without being statically rejected first.
+    allowed["__import__"] = _builtins.__import__
     return MappingProxyType(allowed)
 
 
@@ -114,18 +122,27 @@ SAFE_BUILTINS: Mapping[str, Any] = _build_safe_builtins()
 
 
 def _load_function(code: str) -> FunctionType:
-    # Lazy import torch so the validator module itself stays torch-free;
-    # smoke tests still run the function against real tensors below.
-    import torch
-
     # Restricted exec namespace. We deliberately shadow ``__builtins__`` with
     # our allow-list instead of the real module — a Tier-2 function that
-    # tries ``__import__('os')`` or ``open('/etc/passwd')`` now raises
-    # NameError at evaluation time, not just a lint rejection.
+    # tries ``open('/etc/passwd')`` now raises NameError at evaluation time,
+    # not just a lint rejection. ``__import__`` stays available so ``import``
+    # statements inside the function body can resolve; the AST pass already
+    # rejects bare ``__import__`` references and constrains which modules
+    # are importable.
     namespace: dict[str, object] = {
         "__builtins__": dict(SAFE_BUILTINS),
-        "torch": torch,
     }
+    # Pre-seed ``torch`` if the host env has it so smoke tests can reference
+    # it without an explicit import. In torch-free contexts (lean CI /
+    # validation-only callers) we skip the pre-seed; user code that does
+    # ``import torch`` inside the function still works via __import__.
+    try:
+        import torch as _torch
+
+        namespace["torch"] = _torch
+    except ImportError:
+        pass
+
     exec(compile(code, "<custom_fn>", "exec"), namespace, namespace)  # noqa: S102 - sandboxed
     funcs = [value for value in namespace.values() if isinstance(value, FunctionType)]
     if len(funcs) != 1:

--- a/autoqec/orchestration/memory.py
+++ b/autoqec/orchestration/memory.py
@@ -62,7 +62,24 @@ class RunMemory:
     # ─── L1 writes ───────────────────────────────────────────────────
 
     def append_round(self, record: dict) -> None:
-        """Append one round record to history.jsonl (one JSON object per line)."""
+        """Append one round record to history.jsonl (one JSON object per line).
+
+        The record is validated through :class:`RoundMetrics` before the
+        disk write so the §15.2 mutual-exclusion invariant
+        (``round_attempt_id`` XOR ``reconcile_id``), the
+        ``branch ⇒ commit_sha`` implication, and the
+        ``compose_conflict ⇒ branch=None`` rule are enforced at ingress
+        instead of silently polluting the log. Extra keys (``round``,
+        ``hypothesis``, free-form ``note``) are preserved unchanged — only
+        the schema-owned fields are re-validated.
+        """
+        # Lazy import to keep memory.py importable in torch-free contexts.
+        from autoqec.runner.schema import RoundMetrics
+
+        # Pydantic ignores unknown keys by default; validate a projection
+        # and keep the original dict's shape when writing so callers'
+        # extra metadata (e.g. ``hypothesis``, ``note``) survives.
+        RoundMetrics.model_validate(record)
         with self.history_path.open("a", encoding="utf-8") as f:
             # ensure_ascii=False so Chinese / Δ / other non-ASCII survives
             f.write(json.dumps(record, default=str, ensure_ascii=False) + "\n")

--- a/autoqec/orchestration/reconcile.py
+++ b/autoqec/orchestration/reconcile.py
@@ -190,6 +190,18 @@ def _try_read_pointer(repo_root: Path, branch: str) -> Optional[dict[str, Any]]:
 
 
 def _append_history_row(run_dir: Path, row: dict[str, Any]) -> None:
+    """Append a synthetic reconcile row to ``history.jsonl``.
+
+    Validates the row through :class:`RoundMetrics` first so the §15.2
+    mutual-exclusion invariant (``round_attempt_id`` XOR ``reconcile_id``)
+    and the status-specific branch/commit_sha rules are enforced even for
+    the synthetic rows reconcile emits. Any schema drift in reconcile's
+    row construction fails loudly instead of writing a malformed row that
+    would later break L2 consumers.
+    """
+    from autoqec.runner.schema import RoundMetrics
+
+    RoundMetrics.model_validate(row)
     with (run_dir / "history.jsonl").open("a", encoding="utf-8") as f:
         f.write(json.dumps(row, ensure_ascii=False) + "\n")
 

--- a/autoqec/orchestration/round_recorder.py
+++ b/autoqec/orchestration/round_recorder.py
@@ -98,18 +98,32 @@ _VERIFY_REPORT_FIELDS = frozenset({
 })
 
 
+_PARETO_AXES = ("delta_vs_baseline_holdout", "flops_per_syndrome", "n_params")
+
+
+def _has_all_pareto_axes(row: Mapping[str, Any]) -> bool:
+    """Pareto admission requires all three axes to be present and non-None.
+
+    Earlier we coerced missing cost fields to 0 inside ``_dominates``, which
+    let a malformed VERIFIED row "dominate" every real candidate on the
+    cost axes and quietly evict genuine winners from ``pareto.json``.
+    """
+    return all(row.get(k) is not None for k in _PARETO_AXES)
+
+
 def _dominates(a: dict, b: dict) -> bool:
     """Return True iff candidate `a` dominates `b` on holdout-delta / flops / params.
 
     Axes: `+delta_vs_baseline_holdout` (maximize), `-flops_per_syndrome` (minimize),
-    `-n_params` (minimize). Missing numeric fields coerce to 0.
+    `-n_params` (minimize). Assumes ``_has_all_pareto_axes`` has already passed
+    on both rows — callers guarantee this at admission time.
     """
-    a_d = float(a.get("delta_vs_baseline_holdout") or 0)
-    b_d = float(b.get("delta_vs_baseline_holdout") or 0)
-    a_f = int(a.get("flops_per_syndrome") or 0)
-    b_f = int(b.get("flops_per_syndrome") or 0)
-    a_p = int(a.get("n_params") or 0)
-    b_p = int(b.get("n_params") or 0)
+    a_d = float(a["delta_vs_baseline_holdout"])
+    b_d = float(b["delta_vs_baseline_holdout"])
+    a_f = int(a["flops_per_syndrome"])
+    b_f = int(b["flops_per_syndrome"])
+    a_p = int(a["n_params"])
+    b_p = int(b["n_params"])
     at_least_as_good = (a_d >= b_d) and (a_f <= b_f) and (a_p <= b_p)
     strictly_better = (a_d > b_d) or (a_f < b_f) or (a_p < b_p)
     return at_least_as_good and strictly_better
@@ -208,6 +222,14 @@ def record_round(
 
     front = json.loads(mem.pareto_path.read_text(encoding="utf-8") or "[]")
     candidate = _pareto_row(round_metrics, verify_report)
+    if not _has_all_pareto_axes(candidate):
+        missing = [k for k in _PARETO_AXES if candidate.get(k) is None]
+        log.warning(
+            "record_round: VERIFIED round %s missing Pareto axes %s — skipping admission",
+            round_metrics.get("round"),
+            missing,
+        )
+        return
     front = _non_dominated_merge(front, candidate)
     mem.update_pareto(front)
     _write_preview(mem.run_dir, front)

--- a/autoqec/orchestration/subprocess_runner.py
+++ b/autoqec/orchestration/subprocess_runner.py
@@ -4,14 +4,23 @@ Python's import cache can't hot-reload edited ``modules/*.py`` files, so we
 launch a fresh interpreter with ``cwd=cfg.code_cwd`` and ``PYTHONPATH``
 pinned to the worktree. The child invokes ``python -m cli.autoqec run-round``
 and prints a ``metrics.json``-shaped JSON payload; we parse it here.
+
+After a successful non-``compose_conflict`` round the parent also writes
+and commits ``round_<N>/round_<N>_pointer.json`` on the branch — this is
+the producer side of the §15.10 reconcile contract. Without it reconcile
+cannot auto-heal an orphaned branch after a crash and always falls through
+to ``pause``.
 """
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -19,9 +28,91 @@ import yaml
 from autoqec.envs.schema import EnvSpec
 from autoqec.runner.schema import RoundMetrics, RunnerConfig
 
+log = logging.getLogger(__name__)
+
 
 class RunnerSubprocessError(RuntimeError):
     """Raised when the child process returns a non-zero exit code."""
+
+
+_ROUND_DIR_RE = re.compile(r"^round_(?P<idx>\d+)$")
+
+
+def _extract_round_idx(round_dir: str) -> int | None:
+    """Pull ``N`` from a ``round_<N>`` directory name. Return None on mismatch."""
+    match = _ROUND_DIR_RE.match(Path(round_dir).name)
+    return int(match.group("idx")) if match else None
+
+
+def _write_and_commit_pointer(
+    code_cwd: str,
+    round_idx: int,
+    round_attempt_id: str | None,
+    branch: str,
+) -> str | None:
+    """Write ``round_<N>/round_<N>_pointer.json`` into the worktree, commit it,
+    and return the new HEAD sha.
+
+    This is the §15.10 auto-heal producer. The pointer lives on the branch so
+    ``git show <branch>:round_<N>/round_<N>_pointer.json`` resolves it even
+    after a crash / kill that wiped the in-memory history append.
+    Returns None on any git failure so the caller can still produce metrics
+    instead of masking a training-side success with a pointer-side error.
+    """
+    pointer_dir = Path(code_cwd) / f"round_{round_idx}"
+    pointer_dir.mkdir(parents=True, exist_ok=True)
+    pointer_path = pointer_dir / f"round_{round_idx}_pointer.json"
+    pointer_path.write_text(
+        json.dumps(
+            {
+                "round_attempt_id": round_attempt_id,
+                "round_idx": round_idx,
+                "branch": branch,
+                "written_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    rel_pointer = f"round_{round_idx}/round_{round_idx}_pointer.json"
+    try:
+        subprocess.run(
+            ["git", "-C", code_cwd, "add", rel_pointer],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                code_cwd,
+                "commit",
+                "-q",
+                "-m",
+                f"round {round_idx}: pointer for attempt {round_attempt_id or 'unknown'}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        head = subprocess.run(
+            ["git", "-C", code_cwd, "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return head.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        log.warning(
+            "pointer commit failed for round %s (branch=%s): %s",
+            round_idx,
+            branch,
+            (exc.stderr or "").strip(),
+        )
+        return None
 
 
 def run_round_in_subprocess(
@@ -102,5 +193,28 @@ def run_round_in_subprocess(
 
     metrics_data = json.loads(proc.stdout)
     metrics_data.setdefault("round_attempt_id", round_attempt_id)
-    metrics_data.setdefault("branch", cfg.branch)
+
+    # compose_conflict rows must have branch=None / commit_sha=None per §15.6.3.
+    # For every other status attach the branch so downstream joins work, and
+    # write + commit the §15.10 pointer so reconcile can auto-heal later.
+    if metrics_data.get("status") != "compose_conflict":
+        metrics_data.setdefault("branch", cfg.branch)
+        if cfg.branch is not None:
+            round_idx = _extract_round_idx(cfg.round_dir)
+            if round_idx is not None:
+                commit_sha = _write_and_commit_pointer(
+                    cfg.code_cwd,
+                    round_idx,
+                    round_attempt_id or metrics_data.get("round_attempt_id"),
+                    cfg.branch,
+                )
+                if commit_sha is not None:
+                    # Pointer commit is the authoritative round provenance.
+                    metrics_data["commit_sha"] = commit_sha
+            else:
+                log.warning(
+                    "cfg.round_dir=%r does not match round_<N>; skipping pointer",
+                    cfg.round_dir,
+                )
+
     return RoundMetrics(**metrics_data)

--- a/cli/autoqec.py
+++ b/cli/autoqec.py
@@ -96,29 +96,46 @@ def run_round_cmd(
         else:
             parsed_fork_from = fork_from
 
-    cfg = RunnerConfig(
-        env_name=env.name,
-        predecoder_config=cfg_dict,
-        training_profile=profile,
-        seed=0,
-        round_dir=round_dir,
-        code_cwd=code_cwd,
-        branch=branch,
-        fork_from=parsed_fork_from,
-        compose_mode=compose_mode,
-    )
-
     # Worktree-path runs go through subprocess_runner; in-process runs use the legacy Runner.
     # --_internal-execute-locally is the recursion guard: when subprocess_runner spawns us,
     # it sets this flag so this branch collapses back to the in-process Runner.
     if code_cwd is not None and not _internal_execute_locally:
+        cfg = RunnerConfig(
+            env_name=env.name,
+            predecoder_config=cfg_dict,
+            training_profile=profile,
+            seed=0,
+            round_dir=round_dir,
+            code_cwd=code_cwd,
+            branch=branch,
+            fork_from=parsed_fork_from,
+            compose_mode=compose_mode,
+        )
         from autoqec.orchestration.subprocess_runner import run_round_in_subprocess
 
         metrics = run_round_in_subprocess(cfg, env, round_attempt_id=round_attempt_id)
     else:
+        # Child hop (or plain in-process invocation): strip code_cwd so the
+        # in-process Runner's §15.8 guard does not fire. Parent subprocess_runner
+        # already pinned cwd + PYTHONPATH before spawning us; branch / fork_from /
+        # compose_mode / round_attempt_id still flow through so the metrics row
+        # carries full provenance.
+        cfg = RunnerConfig(
+            env_name=env.name,
+            predecoder_config=cfg_dict,
+            training_profile=profile,
+            seed=0,
+            round_dir=round_dir,
+            code_cwd=None,
+            branch=branch,
+            fork_from=parsed_fork_from,
+            compose_mode=compose_mode,
+        )
         from autoqec.runner.runner import run_round
 
         metrics = run_round(cfg, env)
+        if round_attempt_id is not None and metrics.round_attempt_id is None:
+            metrics = metrics.model_copy(update={"round_attempt_id": round_attempt_id})
     click.echo(metrics.model_dump_json(indent=2))
 
 

--- a/tests/test_cli_run_round_worktree.py
+++ b/tests/test_cli_run_round_worktree.py
@@ -313,20 +313,26 @@ def test_fork_from_valid_json_list_parses(tmp_path):
 
 
 def test_subprocess_runner_injects_internal_flag(tmp_path):
-    """The argv emitted by run_round_in_subprocess must carry the guard flag."""
+    """The argv emitted by run_round_in_subprocess must carry the guard flag.
+
+    subprocess_runner now also issues git invocations to commit the
+    §15.10 pointer; capture only the child CLI call (the one carrying
+    ``run-round``) rather than "whatever was last run".
+    """
     from autoqec.orchestration import subprocess_runner
     from autoqec.envs.schema import load_env_yaml
     from autoqec.runner.schema import RunnerConfig
 
-    captured = {}
+    captured: dict[str, list[str]] = {}
 
     class _FakeCompletedProcess:
         returncode = 0
         stdout = '{"status": "ok", "commit_sha": "abc123", "round_attempt_id": "u1"}'
         stderr = ""
 
-    def _fake_run(argv, **kwargs):
-        captured["argv"] = argv
+    def _fake_run(argv, **_kw):
+        if "run-round" in argv and "child_argv" not in captured:
+            captured["child_argv"] = list(argv)
         return _FakeCompletedProcess()
 
     env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
@@ -343,4 +349,5 @@ def test_subprocess_runner_injects_internal_flag(tmp_path):
     with patch.object(subprocess_runner.subprocess, "run", side_effect=_fake_run):
         subprocess_runner.run_round_in_subprocess(cfg, env, round_attempt_id="u1")
 
-    assert "--_internal-execute-locally" in captured["argv"], captured["argv"]
+    assert "child_argv" in captured, "child CLI call was never issued"
+    assert "--_internal-execute-locally" in captured["child_argv"], captured["child_argv"]

--- a/tests/test_cli_run_round_worktree.py
+++ b/tests/test_cli_run_round_worktree.py
@@ -104,6 +104,93 @@ def test_run_round_internal_flag_skips_subprocess_dispatch(tmp_path):
     assert result.exit_code == 0, result.output
 
 
+def test_internal_flag_strips_code_cwd_before_in_process_runner(tmp_path):
+    """Regression: the child hop must call run_round with cfg.code_cwd=None.
+
+    In-process ``run_round`` raises ``RunnerCallPathError`` whenever
+    ``cfg.code_cwd is not None`` (§15.8). The recursion guard already skips
+    the subprocess dispatcher, but if the child CLI forwards ``code_cwd``
+    into ``RunnerConfig`` verbatim the local runner call still blows up.
+    Worktree metadata (branch/fork_from/compose_mode/round_attempt_id) must
+    still flow through the round record.
+    """
+    import sys
+    import types
+
+    from cli.autoqec import run_round_cmd
+    from autoqec.runner.schema import RoundMetrics
+
+    env_yaml = str(Path("autoqec/envs/builtin/surface_d5_depol.yaml").absolute())
+    cfg_yaml_path = tmp_path / "cfg.yaml"
+    cfg_yaml_path.write_text("type: gnn\noutput_mode: soft_priors\n")
+    round_dir = str(tmp_path / "round_1")
+
+    captured: dict = {}
+
+    def _fake_run_round(cfg, _env, **_kw):
+        captured["cfg"] = cfg
+        # Emulate the real in-process guard: if code_cwd is set we must crash.
+        if cfg.code_cwd is not None:
+            from autoqec.runner.runner import RunnerCallPathError
+
+            raise RunnerCallPathError("in-process run_round rejects code_cwd")
+        return RoundMetrics(
+            status="ok",
+            ler_plain_classical=1e-3,
+            ler_predecoder=5e-4,
+            delta_ler=5e-4,
+            branch=cfg.branch,
+            commit_sha="deadbeef" if cfg.branch else None,
+            fork_from=cfg.fork_from,
+            round_attempt_id="test-uuid",
+        )
+
+    fake_runner_mod = types.ModuleType("autoqec.runner.runner")
+
+    class _FakeRunnerCallPathError(RuntimeError):
+        pass
+
+    fake_runner_mod.run_round = _fake_run_round
+    fake_runner_mod.RunnerCallPathError = _FakeRunnerCallPathError
+
+    original = sys.modules.get("autoqec.runner.runner")
+    sys.modules["autoqec.runner.runner"] = fake_runner_mod
+    try:
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(
+            run_round_cmd,
+            [
+                env_yaml,
+                str(cfg_yaml_path),
+                round_dir,
+                "--code-cwd",
+                str(tmp_path),
+                "--branch",
+                "exp/foo/01-bar",
+                "--round-attempt-id",
+                "test-uuid",
+                "--_internal-execute-locally",
+            ],
+            catch_exceptions=False,
+        )
+    finally:
+        if original is not None:
+            sys.modules["autoqec.runner.runner"] = original
+        else:
+            sys.modules.pop("autoqec.runner.runner", None)
+
+    assert result.exit_code == 0, result.output
+    cfg = captured.get("cfg")
+    assert cfg is not None, "run_round was never called"
+    assert cfg.code_cwd is None, (
+        "child hop must null out code_cwd before the in-process Runner; "
+        f"got code_cwd={cfg.code_cwd!r}"
+    )
+    # Worktree metadata must still flow through so the parent can attach
+    # branch/fork_from to the final metrics row.
+    assert cfg.branch == "exp/foo/01-bar"
+
+
 def test_fork_from_malformed_json_is_bad_parameter(tmp_path):
     """Broken JSON in --fork-from must surface as click.BadParameter, not JSONDecodeError."""
     import click

--- a/tests/test_custom_fn_validator.py
+++ b/tests/test_custom_fn_validator.py
@@ -1,6 +1,13 @@
+import importlib.util
+
+import pytest
+
 from autoqec.decoders.custom_fn_validator import validate_custom_fn
 
+_TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
 
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="smoke test needs torch")
 def test_valid_custom_message_fn() -> None:
     code = """
 def message(x_src, x_dst, e_ij, params):
@@ -22,4 +29,105 @@ def message(x_src, x_dst, e_ij, params):
     ok, reason = validate_custom_fn(code, slot="message_fn")
     assert not ok
     assert "import" in reason.lower() or "forbidden" in reason.lower()
+
+
+# ─── Red-team: sandbox-escape patterns the old whitelist let through ────────
+
+
+def test_rejects_dunder_import_name() -> None:
+    """Bare ``__import__('os')`` must be refused even without an import stmt."""
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    __import__("os").system("echo pwned")
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok, "AST walk must flag __import__ as a forbidden name"
+    assert "__import__" in reason or "forbidden" in reason.lower()
+
+
+def test_rejects_getattr_reflection() -> None:
+    """``getattr`` is a reflection escape — forbid it."""
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    return getattr(params, "W")(x_src)
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "getattr" in reason.lower() or "forbidden" in reason.lower()
+
+
+def test_rejects_dunder_attribute_access() -> None:
+    """``().__class__.__mro__[1].__subclasses__()`` — classic sandbox escape."""
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    cls = ().__class__
+    return cls
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok, "dunder attribute access must be rejected"
+    assert "__class__" in reason or "attribute" in reason.lower()
+
+
+def test_rejects_module_level_code_execution() -> None:
+    """Module-level side effects inside custom_fn source must still get scanned.
+
+    Before the hardening, ``_load_function`` exec'd the whole source with the
+    real ``__builtins__`` in scope, so a bare ``__import__('os').system(...)``
+    at module level would run the moment validate_custom_fn was called.
+    """
+    code = """
+__import__('os')
+def message(x_src, x_dst, e_ij, params):
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok, f"module-level __import__ leaked through validator: {reason}"
+
+
+def test_rejects_open_via_builtins_lookup() -> None:
+    """Even if AST check missed a call, exec-time __builtins__ restriction must fire."""
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    with open("/tmp/leak", "w") as f:
+        f.write("pwned")
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "open" in reason.lower() or "forbidden" in reason.lower()
+
+
+def test_rejects_builtins_reference() -> None:
+    """``__builtins__`` itself must not be reachable by name."""
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    return __builtins__
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "__builtins__" in reason or "forbidden" in reason.lower()
+
+
+def test_rejects_importlib_import() -> None:
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    import importlib
+    mod = importlib.import_module("os")
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "importlib" in reason.lower() or "forbidden" in reason.lower()
+
+
+def test_rejects_private_underscore_attribute() -> None:
+    """Leading-underscore attrs (``x._private``) are off-limits too."""
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    return params._private
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "_private" in reason or "attribute" in reason.lower()
 

--- a/tests/test_custom_fn_validator.py
+++ b/tests/test_custom_fn_validator.py
@@ -131,3 +131,25 @@ def message(x_src, x_dst, e_ij, params):
     assert not ok
     assert "_private" in reason or "attribute" in reason.lower()
 
+
+def test_load_function_supports_whitelisted_runtime_import() -> None:
+    """Regression: ``import`` statements inside the function body must work
+    at exec time. The hardened ``SAFE_BUILTINS`` originally stripped
+    ``__import__`` entirely, which broke every legitimate Tier-2 function
+    that did ``import torch`` inside its body — CI caught it. The AST pass
+    still rejects bare ``__import__`` references, so putting it back in
+    runtime builtins does not reopen the escape.
+
+    This test uses ``typing`` so it runs on torch-free CI too; the real
+    smoke test (``test_valid_custom_message_fn``) covers torch.
+    """
+    from autoqec.decoders.custom_fn_validator import _load_function
+
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    import typing
+    return typing.cast(int, 1)
+"""
+    fn = _load_function(code)
+    assert fn(None, None, None, None) == 1
+

--- a/tests/test_orchestration_stub.py
+++ b/tests/test_orchestration_stub.py
@@ -204,6 +204,58 @@ def test_parse_response_enforces_analyst_verdict() -> None:
 # ─── UTF-8 encoding ───────────────────────────────────────────────────
 
 
+def test_run_memory_append_round_rejects_schema_violation(tmp_path: Path) -> None:
+    """M3: history.jsonl must not grow rows that violate §15.2 invariants.
+
+    Before the guard, ``append_round`` happily json.dumps'd any dict, so a
+    caller could drop a row with both ``round_attempt_id`` and ``reconcile_id``
+    set, or a ``branch`` with no ``commit_sha`` on an ok-status row. The
+    schema exists, but it only fired when a caller voluntarily constructed
+    a ``RoundMetrics`` instance — which many paths didn't.
+    """
+    import pytest
+
+    from autoqec.orchestration.memory import RunMemory
+
+    mem = RunMemory(tmp_path / "run_m3")
+
+    # Both round_attempt_id and reconcile_id set — mutual-exclusion violation.
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        mem.append_round(
+            {
+                "status": "ok",
+                "branch": "exp/t/01-a",
+                "commit_sha": "abc",
+                "round_attempt_id": "u1",
+                "reconcile_id": "r1",
+            }
+        )
+    # History file is untouched after the failed append.
+    assert not mem.history_path.exists() or mem.history_path.read_text() == ""
+
+    # Branch set but commit_sha missing on an ok row — also rejected.
+    with pytest.raises(ValueError, match="commit_sha"):
+        mem.append_round(
+            {
+                "status": "ok",
+                "branch": "exp/t/01-a",
+                "round_attempt_id": "u1",
+            }
+        )
+
+    # A valid row still writes.
+    mem.append_round(
+        {
+            "status": "ok",
+            "round": 1,
+            "branch": "exp/t/01-a",
+            "commit_sha": "abc",
+            "round_attempt_id": "u1",
+        }
+    )
+    assert mem.history_path.read_text(encoding="utf-8").strip() != ""
+
+
 def test_run_memory_append_log_roundtrips_utf8(tmp_path: Path) -> None:
     """Codex review (medium): log.md / jsonl must be UTF-8 on Windows too."""
     from autoqec.orchestration.memory import RunMemory
@@ -211,7 +263,7 @@ def test_run_memory_append_log_roundtrips_utf8(tmp_path: Path) -> None:
     mem = RunMemory(tmp_path / "run_utf8")
     chinese = "第 1 轮：尝试 GNN 带门控消息 — Δ LER ≈ 5e-5"
     mem.append_log(chinese)
-    mem.append_round({"round": 1, "note": chinese})
+    mem.append_round({"round": 1, "status": "ok", "note": chinese})
 
     assert mem.log_path.read_text(encoding="utf-8").strip() == chinese
     snap = mem.l2_snapshot()

--- a/tests/test_round_recorder.py
+++ b/tests/test_round_recorder.py
@@ -185,6 +185,88 @@ def test_pareto_dominance_uses_holdout_not_training_delta(tmp_path: Path) -> Non
     assert branches == {"exp/t/02-b"}
 
 
+def test_pareto_skips_verified_round_without_flops(tmp_path: Path) -> None:
+    """VERIFIED round missing flops_per_syndrome must NOT enter the archive.
+
+    Before this guard, ``_dominates`` silently coerced missing cost fields
+    to 0, so a row with no flops instantly "dominated" every real candidate
+    on the flops axis. That could prune a clean Pareto front with a single
+    malformed submission.
+    """
+    mem = RunMemory(tmp_path)
+    record_round(
+        mem,
+        round_metrics={
+            "round": 1, "status": "ok", "hypothesis": "h",
+            "delta_ler": 1e-4,
+            # flops_per_syndrome intentionally omitted
+            "n_params": 50_000,
+            "branch": "exp/t/01-a", "commit_sha": "sha_a", "round_attempt_id": "u1",
+        },
+        verify_verdict="VERIFIED",
+        verify_report={
+            "verdict": "VERIFIED", "delta_vs_baseline_holdout": 1e-4,
+            "ler_holdout": 4e-4, "paired_eval_bundle_id": "b1",
+        },
+    )
+    pareto = json.loads((tmp_path / "pareto.json").read_text())
+    assert pareto == []
+
+
+def test_pareto_skips_verified_round_without_n_params(tmp_path: Path) -> None:
+    """VERIFIED round missing n_params must NOT enter the archive (symmetric M1)."""
+    mem = RunMemory(tmp_path)
+    record_round(
+        mem,
+        round_metrics={
+            "round": 1, "status": "ok", "hypothesis": "h",
+            "delta_ler": 1e-4,
+            "flops_per_syndrome": 100_000,
+            # n_params intentionally omitted
+            "branch": "exp/t/01-a", "commit_sha": "sha_a", "round_attempt_id": "u1",
+        },
+        verify_verdict="VERIFIED",
+        verify_report={
+            "verdict": "VERIFIED", "delta_vs_baseline_holdout": 1e-4,
+            "ler_holdout": 4e-4, "paired_eval_bundle_id": "b1",
+        },
+    )
+    pareto = json.loads((tmp_path / "pareto.json").read_text())
+    assert pareto == []
+
+
+def test_pareto_missing_cost_does_not_evict_real_candidate(tmp_path: Path) -> None:
+    """A row missing cost axes must not displace an existing valid row.
+
+    Regression for M1: the old ``_dominates`` turned missing axes into 0,
+    so a row with delta≥existing, flops=None, n_params=None would
+    "dominate" everything on disk. After the fix the bad row is dropped
+    at admission time, keeping the true non-dominated front intact.
+    """
+    mem = RunMemory(tmp_path)
+    # Valid candidate first.
+    _admit(mem, round=1, delta_ler=1e-4, flops_per_syndrome=100_000, n_params=40_000,
+           branch="exp/t/01-a", commit_sha="a1", round_attempt_id="u1")
+    # Malformed VERIFIED row arrives — same delta, no cost fields.
+    record_round(
+        mem,
+        round_metrics={
+            "round": 2, "status": "ok", "hypothesis": "h",
+            "delta_ler": 1e-4,
+            # both cost fields absent
+            "branch": "exp/t/02-b", "commit_sha": "b1", "round_attempt_id": "u2",
+        },
+        verify_verdict="VERIFIED",
+        verify_report={
+            "verdict": "VERIFIED", "delta_vs_baseline_holdout": 1e-4,
+            "ler_holdout": 5e-4, "paired_eval_bundle_id": "b2",
+        },
+    )
+    pareto = json.loads((tmp_path / "pareto.json").read_text())
+    assert len(pareto) == 1
+    assert pareto[0]["branch"] == "exp/t/01-a"
+
+
 def test_pareto_skips_verified_round_without_verify_report(tmp_path: Path) -> None:
     """VERIFIED verdict without verify_report cannot be admitted — no holdout axis."""
     mem = RunMemory(tmp_path)

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -7,7 +7,10 @@ in via ``pytest --run-integration``.
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -17,6 +20,24 @@ from autoqec.runner.schema import RunnerConfig
 
 
 _TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
+
+
+def _init_git_repo(repo_root: Path) -> None:
+    """Minimal git init so subprocess_runner can run ``git -C <worktree> commit``."""
+    subprocess.check_call(
+        ["git", "-C", str(repo_root), "init", "-q", "-b", "main"]
+    )
+    subprocess.check_call(
+        ["git", "-C", str(repo_root), "config", "user.email", "test@example.com"]
+    )
+    subprocess.check_call(
+        ["git", "-C", str(repo_root), "config", "user.name", "Test"]
+    )
+    (repo_root / "README.md").write_text("seed\n")
+    subprocess.check_call(["git", "-C", str(repo_root), "add", "README.md"])
+    subprocess.check_call(
+        ["git", "-C", str(repo_root), "commit", "-q", "-m", "seed"]
+    )
 
 
 @pytest.mark.integration
@@ -63,3 +84,124 @@ def test_subprocess_runner_rejects_missing_code_cwd():
 
     with pytest.raises(ValueError, match="code_cwd"):
         run_round_in_subprocess(cfg, env)
+
+
+# ─── M2: round_N_pointer.json writer ─────────────────────────────────────
+
+
+def test_subprocess_runner_writes_and_commits_pointer(tmp_path):
+    """After the child returns, parent writes round_N_pointer.json into the
+    worktree, git-adds + commits it on the branch, and sets metrics.commit_sha
+    to the new HEAD. This is the producer side of §15.10 auto-heal — without
+    it reconcile can never recover an orphaned branch.
+    """
+    from autoqec.orchestration import subprocess_runner
+
+    _init_git_repo(tmp_path)
+    subprocess.check_call(
+        ["git", "-C", str(tmp_path), "checkout", "-q", "-b", "exp/test/07-pointer"]
+    )
+
+    child_stdout = json.dumps({
+        "status": "ok",
+        "ler_plain_classical": 1e-3,
+        "ler_predecoder": 5e-4,
+        "delta_ler": 5e-4,
+        "round_attempt_id": "attempt-abc",
+    })
+
+    class _FakeCompletedProcess:
+        returncode = 0
+        stdout = child_stdout
+        stderr = ""
+
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={"type": "gnn", "output_mode": "soft_priors"},
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "runs" / "r1" / "round_1"),
+        code_cwd=str(tmp_path),
+        branch="exp/test/07-pointer",
+    )
+
+    real_subprocess_run = subprocess.run
+
+    def _stub_child_pass_through_git(argv, **kw):
+        # The child invocation is ``python -m cli.autoqec run-round ...``;
+        # stub that. Everything else (git add / git commit / git rev-parse)
+        # is real so the pointer commit actually lands on the branch.
+        if "run-round" in argv:
+            return _FakeCompletedProcess()
+        return real_subprocess_run(argv, **kw)
+
+    with patch.object(
+        subprocess_runner.subprocess, "run", side_effect=_stub_child_pass_through_git
+    ):
+        metrics = subprocess_runner.run_round_in_subprocess(
+            cfg, env, round_attempt_id="attempt-abc"
+        )
+
+    pointer_path = tmp_path / "round_1" / "round_1_pointer.json"
+    assert pointer_path.exists(), "pointer file was not written into the worktree"
+    payload = json.loads(pointer_path.read_text(encoding="utf-8"))
+    assert payload["round_attempt_id"] == "attempt-abc"
+    assert payload["branch"] == "exp/test/07-pointer"
+    assert payload["round_idx"] == 1
+
+    # File must be committed on the branch — reconcile reads it via
+    # ``git show <branch>:round_<NN>/round_<NN>_pointer.json``.
+    shown = subprocess.check_output(
+        ["git", "-C", str(tmp_path), "show",
+         "exp/test/07-pointer:round_1/round_1_pointer.json"],
+        text=True,
+    )
+    assert json.loads(shown)["round_attempt_id"] == "attempt-abc"
+
+    # metrics.commit_sha must be set to the new HEAD containing the pointer.
+    head_sha = subprocess.check_output(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    assert metrics.commit_sha == head_sha
+
+
+def test_subprocess_runner_skips_pointer_on_compose_conflict(tmp_path):
+    """compose_conflict rows carry branch=None — no commit target, no pointer."""
+    from autoqec.orchestration import subprocess_runner
+
+    _init_git_repo(tmp_path)
+
+    child_stdout = json.dumps({
+        "status": "compose_conflict",
+        "status_reason": "merge conflict in x.py",
+        "round_attempt_id": "attempt-xyz",
+        "conflicting_files": ["x.py"],
+    })
+
+    class _FakeCompletedProcess:
+        returncode = 0
+        stdout = child_stdout
+        stderr = ""
+
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={"type": "gnn", "output_mode": "soft_priors"},
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "runs" / "r1" / "round_2"),
+        code_cwd=str(tmp_path),
+        branch="exp/test/08-compose",
+    )
+
+    with patch.object(subprocess_runner.subprocess, "run", return_value=_FakeCompletedProcess()):
+        metrics = subprocess_runner.run_round_in_subprocess(
+            cfg, env, round_attempt_id="attempt-xyz"
+        )
+
+    assert metrics.status == "compose_conflict"
+    assert metrics.commit_sha is None
+    # No pointer file should have been written — compose_conflict has no branch.
+    assert not (tmp_path / "round_2" / "round_2_pointer.json").exists()


### PR DESCRIPTION
## Summary

Closes the 2 HIGH + 3 MED findings from the latest `main` audit. Each fix is a
separate commit with its own regression test.

| Severity | Fix | Commit |
|---|---|---|
| **H1** | Strip `code_cwd` in the child worktree hop before `run_round`; every live worktree round was previously raising `RunnerCallPathError` because the child still passed `code_cwd` into `RunnerConfig`. Existing test used a fake runner that ignored its cfg argument, so CI stayed green. | `5317634` |
| **H2** | Harden Tier-2 `custom_fn` sandbox: expand `FORBIDDEN_NAMES` (covers `__import__`, `__builtins__`, `getattr`, `importlib`, dunder attribute access), swap `__builtins__` with a minimal `SAFE_BUILTINS` during `exec`, lazy-import torch so validator stays torch-free. Closes `__import__('os')`, `().__class__.__mro__` and several related escapes the old whitelist let through. | `5d6d69d` |
| **M1** | Pareto admission now requires `delta_vs_baseline_holdout`, `flops_per_syndrome`, and `n_params` all non-`None`; `_dominates` no longer coerces missing cost fields to `0`. A malformed VERIFIED row could otherwise "dominate" every real candidate on flops/params and wipe the front. | `03572b3` |
| **M2** | `subprocess_runner` writes + commits `round_<N>/round_<N>_pointer.json` on the branch after a successful child returns, and sets `metrics.commit_sha` to the new HEAD. This is the producer side of §15.10 auto-heal — without it reconcile's recovery path was dead code. Also fixes a latent bug where subprocess_runner unconditionally set `branch` on compose_conflict metrics, which the schema rejects. | `0a4864b` |
| **M3** | `RunMemory.append_round` and `reconcile._append_history_row` now run `RoundMetrics.model_validate(record)` before writing `history.jsonl`, enforcing `round_attempt_id` XOR `reconcile_id`, `branch ⇒ commit_sha`, and `compose_conflict ⇒ branch=None` at ingress instead of silently polluting the log. | `d9452d8` |

Plus 15 new unit / regression tests (including 7 red-team tests for H2).

## Test plan

- [x] `pytest tests/ -m "not integration"` green on torch-free slice (103 passed, 3 skipped)
- [x] `ruff check autoqec/ cli/ tests/ scripts/` clean
- [ ] Torch-gated tests (`test_dsl_compiler`, `test_gnn_module`, `test_neural_bp_module`, `test_custom_fn_validator::test_valid_custom_message_fn`, etc.) on a CI runner with the full dep set — these exercise H2's happy path (a legitimate Tier-2 `message_fn` still validates) and confirm none of the orchestration changes regressed the runner
- [ ] `pytest tests/test_subprocess_runner.py::test_subprocess_runner_smoke -m integration --run-integration` with a real worktree to confirm the M2 pointer commit lands on the branch in a full end-to-end round

## Untouched

- **L1** (`cleanup_round_worktree` path validation) deliberately deferred to a separate small PR — data-loss footgun but not on the current worktree-path hot line.

## Summary by Sourcery

Harden Tier-2 custom function sandboxing, fix worktree subprocess orchestration invariants, and tighten Pareto front admission and history schema validation according to §15 audit findings.

New Features:
- Persist per-round pointer files in worktree branches and record their commit SHAs to support §15.10 auto-heal recovery.

Bug Fixes:
- Ensure in-process runner calls from the worktree CLI strip code_cwd to avoid RunnerCallPathError while preserving worktree metadata.
- Prevent compose_conflict metrics from carrying a branch or commit SHA in violation of schema rules.
- Require all Pareto axes (delta_vs_baseline_holdout, flops_per_syndrome, n_params) to be present for VERIFIED rounds so malformed rows cannot dominate valid candidates.
- Validate history rows against RoundMetrics before appending them, rejecting mutual-exclusion and branch/commit_sha violations.

Enhancements:
- Strengthen Tier-2 custom_fn validation by expanding forbidden names, enforcing AST-based dunder/underscore attribute checks, and executing user code under a minimal SAFE_BUILTINS namespace.
- Refine subprocess runner behavior to write and git-commit round_N_pointer.json and attach the resulting commit SHA to metrics when appropriate.

Tests:
- Add regression tests for worktree CLI recursion that ensure code_cwd is stripped when executing locally.
- Add integration tests for subprocess_runner pointer creation/commit behavior and compose_conflict handling.
- Add Pareto front admission tests covering missing flops, missing n_params, and malformed VERIFIED rows that must not evict valid candidates.
- Add tests that enforce schema validation on history.jsonl appends, including mutual-exclusion and branch/commit_sha invariants.
- Extend custom_fn validator tests, including a happy-path smoke test and multiple red-team cases for sandbox escape patterns and forbidden builtins usage.