### PR TITLE
docs: publish API documentation via GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install docs dependencies
+        run: python -m pip install -e '.[docs]'
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.pyc
 .venv/
 venv/
+site/
 *.pt
 *.ckpt
 runs/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/qualit527/qec-ai-decoder/actions/workflows/ci.yml/badge.svg)](https://github.com/qualit527/qec-ai-decoder/actions/workflows/ci.yml)
 [![testcov](https://codecov.io/github/qualit527/qec-ai-decoder/graph/badge.svg)](https://codecov.io/github/qualit527/qec-ai-decoder)
+[![API docs](https://img.shields.io/badge/API-docs-blue)](https://qualit527.github.io/qec-ai-decoder/)
 
 AutoQEC is an LLM-agent-driven auto-research harness for discovering **neural predecoders** for quantum error-correcting codes. Given an environment triple `(code_spec, noise_model, constraints)`, the system runs 10–20 rounds of *hypothesis → DSL config → training → evaluation → analysis* and emits verified predecoder checkpoints on the accuracy–latency–parameters Pareto front.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# AutoQEC Documentation
+
+This site provides the public developer documentation for AutoQEC.
+
+Use it as the starting point when you need to:
+
+- understand the current public CLI entrypoints
+- inspect the core schemas used by the Runner and orchestration layers
+- understand which artifacts are written under `runs/<run_id>/`
+- navigate to the frozen interface and artifact contracts
+
+## Main entry points
+
+- [API Documentation](api-documentation.md)
+- [Interface Contracts](contracts/interfaces.md)
+- [Round-dir Layout](contracts/round_dir_layout.md)
+
+## Intended audience
+
+This documentation is written for:
+
+- repository maintainers
+- contributors extending the CLI or orchestration flow
+- developers consuming run artifacts or schema payloads
+
+For high-level project context, start from the repository
+[`README.md`](https://github.com/qualit527/qec-ai-decoder/blob/main/README.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name: AutoQEC Documentation
+site_description: Public developer documentation for the AutoQEC research harness
+site_url: https://qualit527.github.io/qec-ai-decoder/
+repo_url: https://github.com/qualit527/qec-ai-decoder
+repo_name: qualit527/qec-ai-decoder
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - API Documentation: api-documentation.md
+  - Contracts:
+      - Interfaces: contracts/interfaces.md
+      - Round Dir Layout: contracts/round_dir_layout.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ dev = [
   "pytest-cov>=5.0",
   "ruff>=0.15",
 ]
+docs = [
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.6",
+]
 
 [tool.setuptools.packages.find]
 include = ["autoqec*", "cli*"]


### PR DESCRIPTION
## Summary
- publish API documentation through a GitHub Pages site instead of relying only on repository Markdown
- add an API docs badge to the README
- add a docs landing page, API documentation page, and Pages build/deploy workflow
- document the current public CLI, core schemas, and artifact layout in English

## What This PR Adds
- `mkdocs.yml` for site navigation and build configuration
- `.github/workflows/docs.yml` for GitHub Pages build and deployment
- `docs/index.md` as the documentation landing page
- `docs/api-documentation.md` as the public API documentation page
- `README.md` API docs badge and docs entry link
- `pyproject.toml` docs dependencies for local docs builds
- `.gitignore` update for the generated `site/` directory

## Scope
This PR documents the current public developer-facing interfaces:
- `python -m cli.autoqec run`
- `python -m cli.autoqec run-round`
- `EnvSpec`
- `RunnerConfig`
- `RoundMetrics`
- run-level and round-level artifacts plus their main consumers

## Test Plan
- `mkdocs build --strict`

Closes #16.

## Summary by Sourcery

Add a MkDocs-based documentation site published via GitHub Pages and link it from the README.

Build:
- Add a docs optional dependency group for building the documentation locally.

CI:
- Introduce a GitHub Actions workflow to build the docs on every change and deploy them to GitHub Pages from the main branch.

Documentation:
- Add an MkDocs configuration, landing page, and navigation for the AutoQEC developer documentation.
- Document public developer-facing APIs, interfaces, and artifact layouts under the new docs site.