### PR TITLE
ci: configure GitHub Pages before docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Configure GitHub Pages
         id: pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- add `actions/configure-pages@v5` to the Docs workflow
- let the workflow initialize GitHub Pages before the deploy step runs
- fix the current `404 Not Found` deployment failure on `actions/deploy-pages`

## Root Cause
The docs site build succeeded, but deployment failed because the repository did not yet have GitHub Pages initialized. The deploy job returned:

- `Failed to create deployment (status: 404)`
- `Ensure GitHub Pages has been enabled`

## Test Plan
- inspect failed run `24817963288`

## Summary by Sourcery

CI:
- Add a configure-pages step to the docs workflow to set up GitHub Pages prior to the deploy step.