### PR TITLE
test: raise coverage above 95 percent

### DIFF
--- a/cli/autoqec.py
+++ b/cli/autoqec.py
@@ -388,6 +388,7 @@ def add_env(out: str, name: str, code_source: str, noise_p: str, backend: str) -
     click.echo(f"Wrote {out}")
 
 
+<<<<<<< HEAD
 @main.command()
 @click.argument("round_dir")
 @click.option("--env", required=True, help="Env YAML path")
@@ -458,6 +459,5 @@ def diagnose(run_dir: str) -> None:
             out["metrics"] = json.loads(p.read_text())
     click.echo(json.dumps(out, indent=2))
 
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/cli/autoqec.py
+++ b/cli/autoqec.py
@@ -388,7 +388,6 @@ def add_env(out: str, name: str, code_source: str, noise_p: str, backend: str) -
     click.echo(f"Wrote {out}")
 
 
-<<<<<<< HEAD
 @main.command()
 @click.argument("round_dir")
 @click.option("--env", required=True, help="Env YAML path")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ source = ["autoqec", "cli"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+precision = 2
+fail_under = 95
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import click
+from click.testing import CliRunner
+import pytest
+
+import cli.autoqec as cli
+from autoqec.envs.schema import load_env_yaml
+from autoqec.runner.schema import RoundMetrics
+
+
+def test_load_example_templates_error_paths(monkeypatch) -> None:
+    class BrokenRoot:
+        def joinpath(self, _name: str):
+            return self
+
+        def iterdir(self):
+            raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(cli.resources, "files", lambda _pkg: BrokenRoot())
+    with pytest.raises(click.ClickException, match="Example templates are not available"):
+        cli.load_example_templates()
+
+    class EmptyRoot:
+        def joinpath(self, _name: str):
+            return self
+
+        def iterdir(self):
+            return []
+
+    monkeypatch.setattr(cli.resources, "files", lambda _pkg: EmptyRoot())
+    with pytest.raises(click.ClickException, match="No example templates were found"):
+        cli.load_example_templates()
+
+
+def test_parse_fork_from_option_variants() -> None:
+    assert cli._parse_fork_from_option(None) is None
+    assert cli._parse_fork_from_option("exp/t/01-a") == "exp/t/01-a"
+    assert cli._parse_fork_from_option('["exp/a","exp/b"]') == ["exp/a", "exp/b"]
+    with pytest.raises(click.BadParameter):
+        cli._parse_fork_from_option("[malformed")
+    with pytest.raises(click.BadParameter):
+        cli._parse_fork_from_option("[1,2]")
+
+
+def test_run_round_internal_cmd_reads_env_bridge(monkeypatch, tmp_path) -> None:
+    captured = {}
+
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_ENV_YAML, "env.yaml")
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_CONFIG_YAML, "config.yaml")
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_ROUND_DIR, str(tmp_path / "round_1"))
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_PROFILE, "dev")
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_CODE_CWD, str(tmp_path))
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_BRANCH, "exp/t/01-a")
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_FORK_FROM, '["exp/a","exp/b"]')
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_COMPOSE_MODE, "pure")
+    monkeypatch.setenv(cli.AUTOQEC_CHILD_ROUND_ATTEMPT_ID, "uuid-1")
+
+    monkeypatch.setattr(cli, "_run_round_impl", lambda **kwargs: captured.update(kwargs))
+    cli.run_round_internal_cmd.callback()
+
+    assert captured["env_yaml"] == "env.yaml"
+    assert captured["_internal_execute_locally"] is True
+    assert captured["round_attempt_id"] == "uuid-1"
+
+
+def test_run_command_rejects_llm_mode(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "load_env_yaml", lambda _path: env)
+    monkeypatch.setattr(cli.time, "strftime", lambda _fmt: "20260423-000000")
+    monkeypatch.setattr(cli, "RunMemory", lambda *_args, **_kwargs: SimpleNamespace())
+    monkeypatch.setattr(cli, "load_example_templates", lambda: [("gnn_small", {"type": "gnn"})])
+
+    runner = CliRunner()
+    result = runner.invoke(cli.run, [env.model_dump()["name"]], catch_exceptions=True)
+    assert result.exit_code != 0
+    assert "LLM mode is not wired" in result.output
+
+
+def test_add_env_writes_yaml_for_mwpm_and_osd(tmp_path) -> None:
+    runner = CliRunner()
+    mwpm_out = tmp_path / "mwpm.yaml"
+    osd_out = tmp_path / "osd.yaml"
+
+    mwpm = runner.invoke(
+        cli.add_env,
+        [
+            "--out",
+            str(mwpm_out),
+            "--name",
+            "surface_like",
+            "--code-source",
+            "circuits/code.stim",
+            "--noise-p",
+            "1e-3,2e-3",
+            "--backend",
+            "mwpm",
+        ],
+        catch_exceptions=False,
+    )
+    osd = runner.invoke(
+        cli.add_env,
+        [
+            "--out",
+            str(osd_out),
+            "--name",
+            "qldpc_like",
+            "--code-source",
+            "circuits/hx.npy",
+            "--noise-p",
+            "1e-3,2e-3",
+            "--backend",
+            "osd",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert mwpm.exit_code == 0
+    assert osd.exit_code == 0
+    assert "Wrote" in mwpm.output
+    assert "Wrote" in osd.output
+
+    mwpm_payload = cli.yaml.safe_load(mwpm_out.read_text())
+    osd_payload = cli.yaml.safe_load(osd_out.read_text())
+    assert mwpm_payload["code"]["type"] == "stim_circuit"
+    assert mwpm_payload["baseline_decoders"] == ["pymatching"]
+    assert osd_payload["code"]["type"] == "parity_check_matrix"
+    assert osd_payload["baseline_decoders"] == ["bposd"]
+
+
+def test_run_command_emits_result_prefix(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "load_env_yaml", lambda _path: env)
+    monkeypatch.setattr(cli.time, "strftime", lambda _fmt: "20260423-000001")
+    monkeypatch.setattr(cli.random, "choice", lambda items: items[0])
+    monkeypatch.setattr(cli, "load_example_templates", lambda: [("gnn_small", {"type": "gnn", "training": {"learning_rate": 1e-3, "batch_size": 1, "epochs": 1}})])
+
+    class MemoryStub:
+        def __init__(self, run_dir, pareto_filename):
+            self.run_dir = Path(run_dir)
+            self.pareto_path = self.run_dir / pareto_filename
+            self.pareto_path.write_text("[]", encoding="utf-8")
+
+        def append_round(self, record):
+            pass
+
+        def update_pareto(self, pareto):
+            self.pareto_path.write_text(json.dumps(pareto), encoding="utf-8")
+
+    monkeypatch.setattr(cli, "RunMemory", MemoryStub)
+    monkeypatch.setattr(
+        cli,
+        "run",
+        cli.run,
+    )
+
+    def fake_run_round(_cfg, _env):
+        return RoundMetrics(status="ok", delta_ler=0.0, flops_per_syndrome=1, n_params=1)
+
+    monkeypatch.setattr("autoqec.runner.runner.run_round", fake_run_round)
+
+    runner_cli = CliRunner()
+    result = runner_cli.invoke(
+        cli.run,
+        [env.model_dump()["name"], "--rounds", "1", "--profile", "dev", "--no-llm"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert cli.RESULT_PREFIX in result.output
+
+
+def test_candidate_pareto_skips_ok_rows_with_missing_metrics() -> None:
+    front = cli._candidate_pareto(
+        [
+            {
+                "round": 1,
+                "status": "ok",
+                "delta_ler": 0.1,
+                "flops_per_syndrome": None,
+                "n_params": 10,
+            },
+            {
+                "round": 2,
+                "status": "ok",
+                "delta_ler": 0.2,
+                "flops_per_syndrome": 5,
+                "n_params": 10,
+            },
+        ]
+    )
+    assert [row["round"] for row in front] == [2]

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -199,7 +199,6 @@ def test_candidate_pareto_skips_ok_rows_with_missing_metrics() -> None:
 
 
 def test_verify_command_writes_report_artifacts(monkeypatch, tmp_path) -> None:
-    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
     round_dir = tmp_path / "round_1"
     round_dir.mkdir()
     (round_dir / "checkpoint.pt").write_text("stub", encoding="utf-8")

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -10,6 +10,7 @@ import pytest
 
 import cli.autoqec as cli
 from autoqec.envs.schema import load_env_yaml
+from autoqec.eval.schema import VerifyReport
 from autoqec.runner.schema import RoundMetrics
 
 
@@ -195,3 +196,104 @@ def test_candidate_pareto_skips_ok_rows_with_missing_metrics() -> None:
         ]
     )
     assert [row["round"] for row in front] == [2]
+
+
+def test_verify_command_writes_report_artifacts(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    round_dir = tmp_path / "round_1"
+    round_dir.mkdir()
+    (round_dir / "checkpoint.pt").write_text("stub", encoding="utf-8")
+    captured = {}
+
+    def fake_verify(ckpt, env_spec, holdout_seeds, n_shots):
+        captured["ckpt"] = ckpt
+        captured["env"] = env_spec
+        captured["holdout_seeds"] = holdout_seeds
+        captured["n_shots"] = n_shots
+        return VerifyReport(
+            verdict="VERIFIED",
+            ler_holdout=0.1,
+            ler_holdout_ci=(0.08, 0.12),
+            delta_ler_holdout=0.02,
+            ler_shuffled=0.11,
+            ablation_sanity_ok=True,
+            holdout_seeds_used=holdout_seeds,
+            seed_leakage_check_ok=True,
+            notes="ok",
+        )
+
+    monkeypatch.setattr("autoqec.eval.independent_eval.independent_verify", fake_verify)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.verify,
+        [str(round_dir), "--env", "autoqec/envs/builtin/surface_d5_depol.yaml", "--n-seeds", "3"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "VERIFIED" in result.output
+    assert captured["ckpt"] == round_dir / "checkpoint.pt"
+    assert captured["holdout_seeds"] == [9000, 9001, 9002]
+    assert json.loads((round_dir / "verification_report.json").read_text())["verdict"] == "VERIFIED"
+    assert "Verification Report" in (round_dir / "verification_report.md").read_text()
+
+
+def test_review_log_handles_missing_history(tmp_path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.review_log, [str(tmp_path)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "No history.jsonl" in result.output
+
+
+def test_review_log_summarizes_existing_run(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "history.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"status": "ok", "train_wallclock_s": 1.0, "hypothesis": "alpha"}),
+                json.dumps({"status": "killed_by_safety", "train_wallclock_s": 3.0, "hypothesis": "beta"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "pareto.json").write_text(json.dumps([{"delta_ler": 0.1}]), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.review_log, [str(run_dir)], catch_exceptions=False)
+    payload = json.loads(result.output)
+    assert payload["n_rounds"] == 2
+    assert payload["n_pareto"] == 1
+    assert payload["n_killed_by_safety"] == 1
+
+
+def test_diagnose_handles_round_dir_and_missing_rounds(tmp_path) -> None:
+    round_dir = tmp_path / "round_1"
+    round_dir.mkdir()
+    (round_dir / "metrics.json").write_text(json.dumps({"status": "ok"}), encoding="utf-8")
+    (round_dir / "train.log").write_text("0\t0.1\n", encoding="utf-8")
+    (round_dir / "config.yaml").write_text("type: gnn\n", encoding="utf-8")
+
+    runner = CliRunner()
+    direct = runner.invoke(cli.diagnose, [str(round_dir)], catch_exceptions=False)
+    payload = json.loads(direct.output)
+    assert payload["has_metrics.json"] is True
+    assert payload["metrics"]["status"] == "ok"
+
+    empty = runner.invoke(cli.diagnose, [str(tmp_path / "empty")], catch_exceptions=False)
+    assert "No round dirs found" in empty.output
+
+
+def test_diagnose_uses_latest_round_from_run_dir(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    (run_dir / "round_1").mkdir(parents=True)
+    (run_dir / "round_2").mkdir(parents=True)
+    (run_dir / "round_2" / "metrics.json").write_text(json.dumps({"status": "compile_error"}), encoding="utf-8")
+    (run_dir / "round_2" / "train.log").write_text("", encoding="utf-8")
+    (run_dir / "round_2" / "config.yaml").write_text("type: gnn\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.diagnose, [str(run_dir)], catch_exceptions=False)
+    payload = json.loads(result.output)
+    assert payload["path"].endswith("round_2")

--- a/tests/test_custom_fn_validator.py
+++ b/tests/test_custom_fn_validator.py
@@ -153,3 +153,86 @@ def message(x_src, x_dst, e_ij, params):
     fn = _load_function(code)
     assert fn(None, None, None, None) == 1
 
+
+def test_rejects_syntax_error() -> None:
+    ok, reason = validate_custom_fn("def broken(", slot="message_fn")
+    assert not ok
+    assert "SyntaxError" in reason
+
+
+def test_rejects_multiple_function_definitions() -> None:
+    code = """
+def one(x_src, x_dst, e_ij, params):
+    return x_src
+
+def two(x_src, x_dst, e_ij, params):
+    return x_dst
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "exactly one function" in reason
+
+
+def test_rejects_wrong_signature() -> None:
+    code = """
+def message(x_src, params):
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "Signature must be" in reason
+
+
+def test_rejects_unknown_slot() -> None:
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="unknown")
+    assert not ok
+    assert "Unknown slot" in reason
+
+
+def test_rejects_non_whitelisted_top_import() -> None:
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    import math
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "whitelist" in reason.lower()
+
+
+def test_rejects_non_whitelisted_from_import() -> None:
+    code = """
+def message(x_src, x_dst, e_ij, params):
+    from math import sqrt
+    return x_src
+"""
+    ok, reason = validate_custom_fn(code, slot="message_fn")
+    assert not ok
+    assert "whitelist" in reason.lower()
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="smoke test needs torch")
+def test_aggregation_smoke_rejects_non_tensor_output() -> None:
+    code = """
+def aggregate(messages, edge_index):
+    return 1
+"""
+    ok, reason = validate_custom_fn(code, slot="aggregation")
+    assert not ok
+    assert "non-tensor" in reason.lower()
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="smoke test needs torch")
+def test_head_smoke_rejects_non_finite_output() -> None:
+    code = """
+def head(hidden_state):
+    import torch
+    return torch.full((hidden_state.shape[0], hidden_state.shape[1]), float("nan"))
+"""
+    ok, reason = validate_custom_fn(code, slot="head")
+    assert not ok
+    assert "nan" in reason.lower()

--- a/tests/test_gnn_module.py
+++ b/tests/test_gnn_module.py
@@ -1,6 +1,13 @@
+import pytest
 import torch
 
-from autoqec.decoders.modules.gnn import BipartiteGNN
+from autoqec.decoders.modules.base import PredecoderBase
+from autoqec.decoders.modules.gnn import (
+    BipartiteGNN,
+    _aggregate,
+    _make_message_fn,
+)
+from autoqec.decoders.modules.mlp import GatedMLP, ResidualMLP, make_head, make_scalar_head
 
 
 def test_gnn_forward_shape() -> None:
@@ -45,3 +52,63 @@ def test_gnn_hard_flip_shape() -> None:
     out = model(syndrome, {"edge_index": edge_index, "n_var": 10, "n_check": 6})
     assert out.shape == (2, 6)
 
+
+def test_make_message_fn_variants_and_helpers() -> None:
+    x = torch.randn(3, 8)
+    gated = _make_message_fn("gated_mlp", 4)
+    residual = _make_message_fn("residual_mlp", 4)
+    normalized = _make_message_fn("normalized_mlp", 4)
+    plain = _make_message_fn("mlp", 4)
+
+    assert gated(torch.randn(3, 8)).shape == (3, 4)
+    assert residual(torch.randn(3, 8)).shape == (3, 4)
+    assert normalized(torch.randn(3, 8)).shape == (3, 4)
+    assert plain(torch.randn(3, 8)).shape == (3, 4)
+    assert GatedMLP(8, 4)(x).shape == (3, 4)
+    assert ResidualMLP(8, 4)(x).shape == (3, 4)
+    assert make_head("mlp_small", 4, 2)(torch.randn(3, 4)).shape == (3, 2)
+    assert make_head("linear", 4, 2)(torch.randn(3, 4)).shape == (3, 2)
+    assert make_scalar_head("mlp_small")(torch.randn(3, 1)).shape == (3, 1)
+    assert make_scalar_head("linear")(torch.randn(3, 1)).shape == (3, 1)
+
+
+def test_aggregate_variants_and_errors() -> None:
+    messages = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    index = torch.tensor([0, 0, 1])
+
+    assert torch.equal(_aggregate("sum", messages, index, 2), torch.tensor([[4.0, 6.0], [5.0, 6.0]]))
+    assert torch.equal(_aggregate("mean", messages, index, 2), torch.tensor([[2.0, 3.0], [5.0, 6.0]]))
+    assert torch.equal(_aggregate("max", messages, index, 2), torch.tensor([[3.0, 4.0], [5.0, 6.0]]))
+    assert torch.equal(_aggregate("attention_pool", messages, index, 2), torch.tensor([[4.0, 6.0], [5.0, 6.0]]))
+    with pytest.raises(ValueError, match="unsupported aggregation"):
+        _aggregate("bogus", messages, index, 2)
+
+
+def test_gnn_normalization_and_3d_forward_cover_extra_paths() -> None:
+    model = BipartiteGNN(
+        n_var=6,
+        n_check=4,
+        hidden_dim=4,
+        layers=1,
+        message_fn="normalized_mlp",
+        aggregation="max",
+        normalization="batch",
+        residual=True,
+        output_mode="soft_priors",
+    )
+    syndrome = torch.rand(2, 3, 4)
+    edge_index = torch.stack(
+        torch.meshgrid(torch.arange(6), torch.arange(4), indexing="ij"),
+        dim=0,
+    ).reshape(2, -1)
+    out = model(syndrome, {"edge_index": edge_index, "n_var": 6, "n_check": 4})
+    assert out.shape == (2, 6)
+    with pytest.raises(ValueError, match="unsupported normalization"):
+        model._apply_norm("bogus", torch.randn(2, 4))
+
+
+def test_predecoder_base_expected_output_shape_switches() -> None:
+    base = PredecoderBase()
+    assert base.expected_output_shape == "[batch, n_faults] float in [0, 1]"
+    base.output_mode = "hard_flip"
+    assert base.expected_output_shape == "[batch, n_checks] long"

--- a/tests/test_independent_eval.py
+++ b/tests/test_independent_eval.py
@@ -1,6 +1,8 @@
 import pytest
+import numpy as np
 import torch
 from pathlib import Path
+import types
 
 
 def test_independent_verify_identity_predecoder(tmp_path):
@@ -48,3 +50,124 @@ def test_independent_verify_rejects_out_of_holdout_range():
     # Seed 5000 is NOT in holdout range [9000, 9999]
     with pytest.raises(ValueError, match="holdout seeds overlaps"):
         independent_verify(Path("nonexistent.pt"), env, holdout_seeds=[5000])
+
+
+def test_load_predecoder_legacy_model_and_double_failure(monkeypatch):
+    from autoqec.eval.independent_eval import _load_predecoder
+
+    ckpt = Path("dummy.pt")
+    ckpt.write_text("stub", encoding="utf-8")
+    model = torch.nn.Linear(1, 1)
+    monkeypatch.setattr(torch, "load", lambda *_args, **_kwargs: {"model": model})
+    assert _load_predecoder(ckpt, 1, 1) is model
+
+    calls = {"n": 0}
+
+    def raising_load(*_args, **_kwargs):
+        calls["n"] += 1
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(torch, "load", raising_load)
+    assert _load_predecoder(ckpt, 1, 1) is None
+    assert calls["n"] == 2
+    ckpt.unlink()
+
+
+def test_load_code_artifacts_and_holdout_sampling_cover_parity_path():
+    from autoqec.eval.independent_eval import _load_code_artifacts, _sample_holdout
+    from autoqec.envs.schema import load_env_yaml
+
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    artifacts = _load_code_artifacts(env)
+    assert artifacts.code_type == "parity_check_matrix"
+    assert artifacts.parity_check_matrix is not None
+
+    synd, err = _sample_holdout(env, artifacts, holdout_seeds=[9000, 9001], n_shots=5)
+    assert synd.shape[0] == 5
+    assert err.shape[0] == 5
+
+    bad_env = env.model_copy(update={"code": env.code.model_copy(update={"type": "tanner_graph"})})
+    with pytest.raises(ValueError, match="Unsupported code type"):
+        _load_code_artifacts(bad_env)
+
+
+def test_decode_holdout_covers_model_none_and_osd_path(monkeypatch):
+    from autoqec.eval import independent_eval as ie
+    from autoqec.envs.schema import load_env_yaml
+
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    artifacts = ie._load_code_artifacts(env)
+    syndrome = torch.zeros((2, artifacts.n_check), dtype=torch.float32)
+    target = torch.zeros((2, artifacts.n_var), dtype=torch.int64)
+
+    monkeypatch.setattr(ie, "_sample_holdout", lambda *_args, **_kwargs: (syndrome, target))
+    plain, pred, shuffled = ie._decode_holdout(None, env, artifacts, [9000], 2)
+    assert plain.shape == pred.shape == shuffled.shape == (2,)
+
+
+def test_decode_holdout_sets_parity_ctx_and_ablation(monkeypatch):
+    from autoqec.eval import independent_eval as ie
+    from autoqec.envs.schema import load_env_yaml
+
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    artifacts = ie._load_code_artifacts(env)
+    syndrome = torch.zeros((2, artifacts.n_check), dtype=torch.float32)
+    target = torch.zeros((2, artifacts.n_var), dtype=torch.int64)
+    monkeypatch.setattr(ie, "_sample_holdout", lambda *_args, **_kwargs: (syndrome, target))
+
+    class FakeModel(torch.nn.Module):
+        output_mode = "soft_priors"
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+        def forward(self, syndrome, ctx):
+            assert "parity_check_matrix" in ctx
+            return torch.full((syndrome.shape[0], artifacts.n_var), 0.1)
+
+    model = FakeModel()
+    monkeypatch.setattr(ie, "decode_with_predecoder", lambda *_args, **_kwargs: np.zeros((2, artifacts.n_var), dtype=np.int64))
+    plain, pred, shuffled = ie._decode_holdout(model, env, artifacts, [9000], 2)
+    assert plain.shape == pred.shape == shuffled.shape == (2,)
+
+
+def test_independent_verify_can_return_failed_and_verified(monkeypatch):
+    from autoqec.eval import independent_eval as ie
+    from autoqec.envs.schema import load_env_yaml
+
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    monkeypatch.setattr(ie, "_load_code_artifacts", lambda _env: types.SimpleNamespace(n_var=1, n_check=1))
+    monkeypatch.setattr(ie, "_load_predecoder", lambda *_args, **_kwargs: object())
+
+    def fake_decode_failed(*_args, **_kwargs):
+        return (
+            np.array([0, 0, 0], dtype=np.int32),
+            np.array([1, 1, 1], dtype=np.int32),
+            np.array([0, 0, 0], dtype=np.int32),
+        )
+
+    monkeypatch.setattr(ie, "_decode_holdout", fake_decode_failed)
+    monkeypatch.setattr(
+        ie,
+        "bootstrap_ci_mean",
+        lambda outcomes, *_args, **_kwargs: (float(outcomes.mean()), 0.1, 0.1001),
+    )
+    failed = ie.independent_verify(Path("dummy.pt"), env, holdout_seeds=[9000], n_shots=3)
+    assert failed.verdict == "FAILED"
+
+    def fake_decode_verified(*_args, **_kwargs):
+        return (
+            np.array([1, 1, 1], dtype=np.int32),
+            np.array([0, 0, 0], dtype=np.int32),
+            np.array([1, 1, 1], dtype=np.int32),
+        )
+
+    monkeypatch.setattr(ie, "_decode_holdout", fake_decode_verified)
+    monkeypatch.setattr(
+        ie,
+        "bootstrap_ci_mean",
+        lambda outcomes, *_args, **_kwargs: (float(outcomes.mean()), 0.4, 0.5),
+    )
+    verified = ie.independent_verify(Path("dummy.pt"), env, holdout_seeds=[9000], n_shots=3)
+    assert verified.verdict == "VERIFIED"

--- a/tests/test_neural_bp_module.py
+++ b/tests/test_neural_bp_module.py
@@ -23,3 +23,63 @@ def test_neural_bp_forward_shape() -> None:
     assert torch.all(out >= 0)
     assert torch.all(out <= 1)
 
+
+def test_neural_bp_covers_fixed_damping_per_check_and_hard_flip_paths() -> None:
+    n_var, n_check = 6, 4
+    edge_index = torch.stack(
+        torch.meshgrid(torch.arange(n_var), torch.arange(n_check), indexing="ij"),
+        dim=0,
+    ).reshape(2, -1)
+    parity = torch.randint(0, 2, (n_check, n_var))
+    syndrome = torch.rand(3, 2, n_check)
+
+    model = NeuralBP(
+        n_var=n_var,
+        n_check=n_check,
+        iterations=2,
+        weight_sharing="per_check",
+        damping="fixed",
+        output_mode="hard_flip",
+    )
+    out = model(
+        syndrome,
+        {
+            "edge_index": edge_index,
+            "n_var": n_var,
+            "n_check": n_check,
+            "parity_check_matrix": parity,
+            "prior_p": None,
+        },
+    )
+    assert out.shape == (3, n_check)
+    assert model._damping_at(0).dim() == 0
+    assert model._check_weight_at(0, edge_index[1]).shape[0] == edge_index.shape[1]
+
+
+def test_neural_bp_covers_learnable_vector_and_no_parity_fallback() -> None:
+    n_var, n_check = 5, 3
+    edge_index = torch.stack(
+        torch.meshgrid(torch.arange(n_var), torch.arange(n_check), indexing="ij"),
+        dim=0,
+    ).reshape(2, -1)
+    syndrome = torch.rand(2, n_check)
+
+    model = NeuralBP(
+        n_var=n_var,
+        n_check=n_check,
+        iterations=3,
+        weight_sharing="none",
+        damping="learnable_vector",
+        output_mode="hard_flip",
+    )
+    out = model(
+        syndrome,
+        {
+            "edge_index": edge_index,
+            "n_var": n_var,
+            "n_check": n_check,
+            "prior_p": torch.full((n_var,), 0.2),
+        },
+    )
+    assert out.shape == (2, n_check)
+    assert model._damping_at(1).shape == torch.Size([])

--- a/tests/test_runner_core.py
+++ b/tests/test_runner_core.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
-import pytest
 import torch
 from torch import nn
 

--- a/tests/test_runner_core.py
+++ b/tests/test_runner_core.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from autoqec.envs.schema import load_env_yaml
+from autoqec.runner import runner
+from autoqec.runner.data import CodeArtifacts
+from autoqec.runner.safety import RunnerSafety
+from autoqec.runner.schema import RunnerConfig
+
+
+class FakeModel(nn.Module):
+    def __init__(self, output_mode: str, output_width: int):
+        super().__init__()
+        self.output_mode = output_mode
+        self.output_width = output_width
+        self.weight = nn.Parameter(torch.tensor(0.1))
+
+    def forward(self, syndrome: torch.Tensor, ctx: dict) -> torch.Tensor:
+        batch = syndrome.shape[0]
+        if self.output_mode == "soft_priors":
+            return torch.sigmoid(self.weight).expand(batch, self.output_width)
+        return self.weight.expand(batch, self.output_width)
+
+
+class FakeNaNModel(nn.Module):
+    def __init__(self, output_mode: str, output_width: int):
+        super().__init__()
+        self.output_mode = output_mode
+        self.output_width = output_width
+        self.weight = nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, syndrome: torch.Tensor, ctx: dict) -> torch.Tensor:
+        batch = syndrome.shape[0]
+        return torch.full((batch, self.output_width), float("nan"), device=syndrome.device)
+
+
+def _parity_artifacts(n_var: int = 5, n_check: int = 3) -> CodeArtifacts:
+    parity = np.zeros((n_check, n_var), dtype=np.uint8)
+    edge_index = torch.tensor([[0, 1, 2], [0, 1, 2]], dtype=torch.long)
+    return CodeArtifacts(
+        code_type="parity_check_matrix",
+        code_artifact=parity,
+        edge_index=edge_index,
+        n_var=n_var,
+        n_check=n_check,
+        prior_p=torch.full((n_var,), 0.05, dtype=torch.float32),
+        parity_check_matrix=parity,
+    )
+
+
+def _stim_artifacts(n_var: int = 5, n_check: int = 3) -> CodeArtifacts:
+    circuit = object()
+    edge_index = torch.tensor([[0, 1, 2], [0, 1, 2]], dtype=torch.long)
+    return CodeArtifacts(
+        code_type="stim_circuit",
+        code_artifact=circuit,
+        edge_index=edge_index,
+        n_var=n_var,
+        n_check=n_check,
+        prior_p=torch.full((n_var,), 0.05, dtype=torch.float32),
+    )
+
+
+def test_profile_params_and_failure_rate_cover_both_modes() -> None:
+    stim_env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    parity_env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+
+    assert runner._profile_params(stim_env, "dev") == {
+        "n_shots_train": 256,
+        "n_shots_val": 64,
+        "epochs_cap": 1,
+    }
+    assert runner._profile_params(stim_env, "prod") == {
+        "n_shots_train": 2048,
+        "n_shots_val": 256,
+        "epochs_cap": 3,
+    }
+
+    preds = np.array([[0, 1], [1, 1]])
+    targets = np.array([[0, 1], [0, 1]])
+    assert runner._failure_rate(stim_env, preds, targets) == 0.5
+    assert runner._failure_rate(parity_env, preds, targets) == 0.5
+
+
+def test_set_seed_calls_cpu_and_cuda_seeders(monkeypatch) -> None:
+    called = []
+    monkeypatch.setattr(runner.random, "seed", lambda seed: called.append(("random", seed)))
+    monkeypatch.setattr(runner.np.random, "seed", lambda seed: called.append(("numpy", seed)))
+    monkeypatch.setattr(runner.torch, "manual_seed", lambda seed: called.append(("torch", seed)))
+    monkeypatch.setattr(runner.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        runner.torch.cuda,
+        "manual_seed_all",
+        lambda seed: called.append(("cuda", seed)),
+    )
+
+    runner._set_seed(7)
+
+    assert called == [
+        ("random", 7),
+        ("numpy", 7),
+        ("torch", 7),
+        ("cuda", 7),
+    ]
+
+
+def test_run_round_returns_compile_error_when_model_build_fails(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={"training": {"learning_rate": 1e-3, "batch_size": 1, "epochs": 1}},
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "round_1"),
+    )
+
+    monkeypatch.setattr(runner, "load_code_artifacts", lambda _env: _stim_artifacts())
+    monkeypatch.setattr(
+        runner,
+        "compile_predecoder",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    metrics = runner.run_round(cfg, env)
+    assert metrics.status == "compile_error"
+    assert metrics.status_reason == "boom"
+
+
+def test_run_round_returns_vram_precheck_kill(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={
+            "gnn": {"hidden_dim": 128},
+            "training": {"learning_rate": 1e-3, "batch_size": 4, "epochs": 1},
+        },
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "round_1"),
+    )
+    monkeypatch.setattr(runner, "load_code_artifacts", lambda _env: _parity_artifacts())
+    monkeypatch.setattr(runner, "compile_predecoder", lambda *_args, **_kwargs: FakeModel("soft_priors", 5))
+    monkeypatch.setattr(runner.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(runner, "estimate_vram_gb", lambda *_args, **_kwargs: 10.0)
+    monkeypatch.setattr(runner.torch.cuda, "mem_get_info", lambda: (1_000_000, 1_000_000))
+
+    metrics = runner.run_round(cfg, env, safety=RunnerSafety(VRAM_PRE_CHECK=True))
+    assert metrics.status == "killed_by_safety"
+    assert "VRAM estimate" in (metrics.status_reason or "")
+
+
+def test_run_round_returns_wall_clock_cutoff(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={
+            "type": "gnn",
+            "output_mode": "soft_priors",
+            "training": {"learning_rate": 1e-3, "batch_size": 1, "epochs": 1},
+        },
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "round_1"),
+    )
+    monkeypatch.setattr(runner, "load_code_artifacts", lambda _env: _parity_artifacts())
+    monkeypatch.setattr(runner, "compile_predecoder", lambda *_args, **_kwargs: FakeModel("soft_priors", 5))
+    monkeypatch.setattr(
+        runner,
+        "sample_syndromes",
+        lambda *_args, **_kwargs: (
+            torch.zeros((2, 3), dtype=torch.float32),
+            torch.zeros((2, 5), dtype=torch.float32),
+        ),
+    )
+    monkeypatch.setattr(runner.torch.cuda, "is_available", lambda: False)
+    time_points = iter([0.0, 1.0, 1.0])
+    monkeypatch.setattr(runner.time, "time", lambda: next(time_points))
+
+    metrics = runner.run_round(
+        cfg,
+        env,
+        safety=RunnerSafety(WALL_CLOCK_HARD_CUTOFF_S=0, VRAM_PRE_CHECK=False),
+    )
+    assert metrics.status == "killed_by_safety"
+    assert "wall_clock_cutoff" in (metrics.status_reason or "")
+
+
+def test_run_round_returns_nan_rate_kill(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={
+            "type": "gnn",
+            "output_mode": "hard_flip",
+            "training": {"learning_rate": 1e-3, "batch_size": 1, "epochs": 1},
+        },
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "round_1"),
+    )
+    monkeypatch.setattr(runner, "load_code_artifacts", lambda _env: _parity_artifacts())
+    monkeypatch.setattr(runner, "compile_predecoder", lambda *_args, **_kwargs: FakeNaNModel("hard_flip", 3))
+    monkeypatch.setattr(
+        runner,
+        "sample_syndromes",
+        lambda *_args, **_kwargs: (
+            torch.zeros((2, 3), dtype=torch.float32),
+            torch.zeros((2, 5), dtype=torch.float32),
+        ),
+    )
+    monkeypatch.setattr(runner.torch.cuda, "is_available", lambda: False)
+
+    metrics = runner.run_round(
+        cfg,
+        env,
+        safety=RunnerSafety(VRAM_PRE_CHECK=False, MAX_NAN_RATE=0.0),
+    )
+    assert metrics.status == "killed_by_safety"
+    assert "NaN rate" in (metrics.status_reason or "")
+
+
+def test_run_round_success_soft_priors_parity_path(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={
+            "type": "gnn",
+            "output_mode": "soft_priors",
+            "training": {"learning_rate": 1e-3, "batch_size": 2, "epochs": 1},
+        },
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "round_1"),
+    )
+    train_pair = (
+        torch.zeros((2, 3), dtype=torch.float32),
+        torch.zeros((2, 5), dtype=torch.float32),
+    )
+    val_pair = (
+        torch.zeros((2, 3), dtype=torch.float32),
+        torch.zeros((2, 5), dtype=torch.int64),
+    )
+    calls = iter([train_pair, val_pair])
+
+    monkeypatch.setattr(runner, "load_code_artifacts", lambda _env: _parity_artifacts())
+    monkeypatch.setattr(runner, "compile_predecoder", lambda *_args, **_kwargs: FakeModel("soft_priors", 5))
+    monkeypatch.setattr(runner, "sample_syndromes", lambda *_args, **_kwargs: next(calls))
+    monkeypatch.setattr(runner.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(runner, "decode_with_predecoder", lambda *_args, **_kwargs: np.zeros((2, 5), dtype=np.int64))
+    monkeypatch.setattr(runner, "estimate_flops", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("no flop")))
+
+    metrics = runner.run_round(cfg, env, safety=RunnerSafety(VRAM_PRE_CHECK=False))
+    round_dir = Path(cfg.round_dir)
+    assert metrics.status == "ok"
+    assert metrics.flops_per_syndrome == 2
+    assert round_dir.joinpath("metrics.json").exists()
+    assert round_dir.joinpath("checkpoint.pt").exists()
+    assert round_dir.joinpath("train.log").exists()
+
+
+def test_run_round_success_hard_flip_mwpm_path(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    cfg = RunnerConfig(
+        env_name=env.name,
+        predecoder_config={
+            "type": "gnn",
+            "output_mode": "hard_flip",
+            "training": {"learning_rate": 1e-3, "batch_size": 2, "epochs": 1},
+        },
+        training_profile="dev",
+        seed=0,
+        round_dir=str(tmp_path / "round_1"),
+    )
+    train_pair = (
+        torch.zeros((2, 3), dtype=torch.float32),
+        torch.zeros((2, 1), dtype=torch.int64),
+    )
+    val_pair = (
+        torch.zeros((2, 3), dtype=torch.float32),
+        torch.zeros((2, 1), dtype=torch.int64),
+    )
+    calls = iter([train_pair, val_pair])
+
+    class FakeBaseline:
+        def decode_batch(self, detections: np.ndarray) -> np.ndarray:
+            return np.zeros((detections.shape[0], 1), dtype=np.int64)
+
+    fake_class = type(
+        "FakeBaselineClass",
+        (),
+        {"from_circuit": staticmethod(lambda _artifact: FakeBaseline())},
+    )
+
+    monkeypatch.setattr(runner, "load_code_artifacts", lambda _env: _stim_artifacts())
+    monkeypatch.setattr(runner, "compile_predecoder", lambda *_args, **_kwargs: FakeModel("hard_flip", 3))
+    monkeypatch.setattr(runner, "sample_syndromes", lambda *_args, **_kwargs: next(calls))
+    monkeypatch.setattr(runner.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(runner, "PymatchingBaseline", fake_class)
+    monkeypatch.setattr(runner, "decode_with_predecoder", lambda *_args, **_kwargs: np.zeros((2, 1), dtype=np.int64))
+    monkeypatch.setattr(runner, "estimate_flops", lambda *_args, **_kwargs: 123)
+
+    metrics = runner.run_round(cfg, env, safety=RunnerSafety(VRAM_PRE_CHECK=False))
+    assert metrics.status == "ok"
+    assert metrics.flops_per_syndrome == 123

--- a/tests/test_runner_data.py
+++ b/tests/test_runner_data.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import numpy as np
+import stim
+import torch
+
+from autoqec.envs.schema import load_env_yaml
+from autoqec.runner import data as runner_data
+
+
+def test_select_seeds_respects_range_and_caps_unique_count() -> None:
+    assert runner_data._select_seeds((10, 12), 0) == [10]
+    assert runner_data._select_seeds((10, 12), 2) == [10, 11]
+    assert runner_data._select_seeds((10, 30), 20) == list(range(10, 18))
+
+
+def test_stim_artifacts_and_sampling_cover_stim_path() -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    artifacts = runner_data.load_code_artifacts(env)
+
+    assert artifacts.code_type == "stim_circuit"
+    assert artifacts.n_var > 0
+    assert artifacts.n_check > 0
+    assert artifacts.edge_index.shape[0] == 2
+    assert artifacts.prior_p.shape[0] == artifacts.n_var
+
+    syndrome, targets = runner_data.sample_syndromes(
+        env,
+        artifacts,
+        env.noise.seed_policy.train,
+        5,
+    )
+    assert syndrome.shape[0] == 5
+    assert syndrome.shape[1] == artifacts.n_check
+    assert targets.shape[0] == 5
+
+
+def test_stim_edge_index_and_prior_skips_non_error_instructions() -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    circuit = stim.Circuit.from_file(env.code.source)
+    edge_index, prior = runner_data._stim_edge_index_and_prior(circuit)
+
+    assert edge_index.shape[0] == 2
+    assert prior.ndim == 1
+    assert prior.numel() > 0
+
+
+def test_parity_edge_index_and_sampling_cover_parity_path() -> None:
+    env = load_env_yaml("autoqec/envs/builtin/bb72_depol.yaml")
+    artifacts = runner_data.load_code_artifacts(env)
+
+    assert artifacts.code_type == "parity_check_matrix"
+    assert artifacts.parity_check_matrix is not None
+    assert artifacts.edge_index.shape[0] == 2
+    assert artifacts.prior_p.shape[0] == artifacts.n_var
+
+    syndrome, errors = runner_data.sample_syndromes(
+        env,
+        artifacts,
+        env.noise.seed_policy.train,
+        6,
+    )
+    assert syndrome.shape == (6, artifacts.n_check)
+    assert errors.shape == (6, artifacts.n_var)
+
+
+def test_parity_edge_index_uses_nonzero_entries() -> None:
+    parity = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.uint8)
+    edge_index = runner_data._parity_edge_index(parity)
+    assert torch.equal(edge_index, torch.tensor([[0, 2, 1], [0, 0, 1]]))
+
+
+def test_sample_parity_respects_requested_shot_count() -> None:
+    parity = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.uint8)
+    syndrome, errors = runner_data._sample_parity(parity, 0.1, (1, 5), 3)
+    assert syndrome.shape == (3, 2)
+    assert errors.shape == (3, 3)
+
+
+def test_load_code_artifacts_rejects_unsupported_code_type() -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    bad_env = env.model_copy(
+        update={"code": env.code.model_copy(update={"type": "tanner_graph"})}
+    )
+    try:
+        runner_data.load_code_artifacts(bad_env)
+    except ValueError as exc:
+        assert "Unsupported code type" in str(exc)
+    else:
+        raise AssertionError("expected unsupported code type to raise ValueError")

--- a/tests/test_small_coverage_edges.py
+++ b/tests/test_small_coverage_edges.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import click
+from click.testing import CliRunner
+import numpy as np
+import pytest
+import stim
+import torch
+
+import cli.autoqec as cli
+from autoqec.agents.dispatch import parse_response
+from autoqec.decoders.backend_adapter import decode_with_predecoder
+from autoqec.decoders.dsl_schema import PredecoderDSL
+from autoqec.envs.schema import load_env_yaml
+from autoqec.runner.flops import estimate_flops
+from autoqec.runner.schema import RoundMetrics
+
+
+def test_estimate_flops_success_and_fallback(monkeypatch) -> None:
+    class FakeAnalysis:
+        def __init__(self, _model, _inputs):
+            pass
+
+        def total(self):
+            return 123
+
+    fake_module = types.ModuleType("fvcore.nn")
+    fake_module.FlopCountAnalysis = FakeAnalysis
+    monkeypatch.setitem(sys.modules, "fvcore.nn", fake_module)
+
+    model = torch.nn.Linear(2, 3)
+    assert estimate_flops(model, (torch.randn(1, 2),)) == 123
+
+    class RaisingAnalysis:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("nope")
+
+    fake_module.FlopCountAnalysis = RaisingAnalysis
+    assert estimate_flops(model, (torch.randn(1, 2),)) == 2 * sum(p.numel() for p in model.parameters())
+
+
+def test_backend_adapter_error_branches(monkeypatch) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+
+    with pytest.raises(TypeError, match="Stim circuit artifact"):
+        decode_with_predecoder(np.zeros((1, 2)), env, np.zeros((1, 2)), np.zeros((2, 2)), "hard_flip")
+
+    class FakeMatching:
+        def decode_batch(self, arr):
+            return arr.astype(np.int64)
+
+    fake_pymatching = types.ModuleType("pymatching")
+    fake_pymatching.Matching = type(
+        "Matching",
+        (),
+        {"from_detector_error_model": staticmethod(lambda _dem: FakeMatching())},
+    )
+    monkeypatch.setitem(sys.modules, "pymatching", fake_pymatching)
+    circuit = stim.Circuit.from_file(env.code.source)
+    syndrome = np.zeros((2, circuit.num_detectors), dtype=np.uint8)
+    out = decode_with_predecoder(np.ones_like(syndrome), env, syndrome, circuit, "soft_priors")
+    assert out.shape[0] == 2
+
+    bad_env = env.model_copy(update={"classical_backend": "unknown"})
+    with pytest.raises(ValueError, match="Unknown backend"):
+        decode_with_predecoder(np.zeros((1, 2)), bad_env, np.zeros((1, 2)), circuit, "hard_flip")
+
+
+def test_dsl_schema_family_specific_errors() -> None:
+    base_training = {
+        "learning_rate": 1e-3,
+        "batch_size": 4,
+        "epochs": 1,
+        "loss": "bce",
+        "profile": "dev",
+    }
+    with pytest.raises(ValueError, match="gnn spec required"):
+        PredecoderDSL(type="gnn", output_mode="soft_priors", head="linear", training=base_training)
+
+    with pytest.raises(ValueError, match="not allowed when type='gnn'"):
+        PredecoderDSL(
+            type="gnn",
+            output_mode="soft_priors",
+            gnn={
+                "layers": 1,
+                "hidden_dim": 8,
+                "message_fn": "mlp",
+                "aggregation": "sum",
+                "normalization": "none",
+                "residual": False,
+                "edge_features": [],
+            },
+            neural_bp={
+                "iterations": 1,
+                "weight_sharing": "per_layer",
+                "damping": "learnable_scalar",
+                "attention_aug": False,
+                "attention_heads": 1,
+            },
+            head="linear",
+            training=base_training,
+        )
+
+    with pytest.raises(ValueError, match="neural_bp spec required"):
+        PredecoderDSL(type="neural_bp", output_mode="soft_priors", head="linear", training=base_training)
+
+    with pytest.raises(ValueError, match="not allowed when type='neural_bp'"):
+        PredecoderDSL(
+            type="neural_bp",
+            output_mode="soft_priors",
+            gnn={
+                "layers": 1,
+                "hidden_dim": 8,
+                "message_fn": "mlp",
+                "aggregation": "sum",
+                "normalization": "none",
+                "residual": False,
+                "edge_features": [],
+            },
+            neural_bp={
+                "iterations": 1,
+                "weight_sharing": "per_layer",
+                "damping": "learnable_scalar",
+                "attention_aug": False,
+                "attention_heads": 1,
+            },
+            head="linear",
+            training=base_training,
+        )
+
+
+def test_machine_state_gpu_snapshot_success(monkeypatch) -> None:
+    fake_torch = types.ModuleType("torch")
+
+    class _Props:
+        total_memory = 8_000_000_000
+
+    class _FakeCuda:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        @staticmethod
+        def mem_get_info():
+            return (4_000_000_000, 8_000_000_000)
+
+        @staticmethod
+        def get_device_name(_idx: int) -> str:
+            return "Fake GPU"
+
+        @staticmethod
+        def get_device_properties(_idx: int):
+            return _Props()
+
+    fake_torch.cuda = _FakeCuda()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    from autoqec.tools.machine_state import _gpu_snapshot
+
+    snapshot = _gpu_snapshot()
+    assert snapshot["name"] == "Fake GPU"
+    assert snapshot["vram_free_gb"] == 4.0
+
+
+def test_parse_response_unknown_role_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown role"):
+        parse_response("ghost", "```json\n{}\n```")  # type: ignore[arg-type]
+
+
+def test_run_round_impl_dispatches_subprocess_branch(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("type: gnn\noutput_mode: soft_priors\ntraining:\n  learning_rate: 0.001\n  batch_size: 1\n  epochs: 1\n  loss: bce\n  profile: dev\n")
+    captured = {}
+
+    monkeypatch.setattr(cli, "load_env_yaml", lambda _path: env)
+    monkeypatch.setattr(
+        cli,
+        "yaml",
+        types.SimpleNamespace(safe_load=lambda _f: {"type": "gnn", "output_mode": "soft_priors", "training": {"learning_rate": 0.001, "batch_size": 1, "epochs": 1, "loss": "bce", "profile": "dev"}}),
+    )
+
+    fake_module = types.ModuleType("autoqec.orchestration.subprocess_runner")
+
+    def fake_run_round_in_subprocess(cfg, _env, round_attempt_id=None):
+        captured["cfg"] = cfg
+        captured["round_attempt_id"] = round_attempt_id
+        return RoundMetrics(status="ok")
+
+    fake_module.run_round_in_subprocess = fake_run_round_in_subprocess
+    monkeypatch.setitem(sys.modules, "autoqec.orchestration.subprocess_runner", fake_module)
+    monkeypatch.setattr(click, "echo", lambda msg: captured.setdefault("echo", msg))
+
+    cli._run_round_impl(
+        env_yaml="env.yaml",
+        config_yaml=str(cfg_path),
+        round_dir=str(tmp_path / "round_1"),
+        profile="dev",
+        code_cwd=str(tmp_path),
+        branch="exp/t/01-a",
+        fork_from=None,
+        compose_mode=None,
+        round_attempt_id="uuid-1",
+        _internal_execute_locally=False,
+    )
+
+    assert captured["cfg"].code_cwd == str(tmp_path)
+    assert captured["round_attempt_id"] == "uuid-1"
+
+
+def test_run_command_errors_when_dev_safe_templates_are_missing(monkeypatch, tmp_path) -> None:
+    env = load_env_yaml("autoqec/envs/builtin/surface_d5_depol.yaml")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "load_env_yaml", lambda _path: env)
+    monkeypatch.setattr(cli.time, "strftime", lambda _fmt: "20260423-000002")
+    monkeypatch.setattr(cli, "RunMemory", lambda *_args, **_kwargs: types.SimpleNamespace(append_round=lambda _r: None, update_pareto=lambda _p: None))
+    monkeypatch.setattr(cli, "load_example_templates", lambda: [("other", {"type": "gnn", "training": {"learning_rate": 1e-3, "batch_size": 1, "epochs": 1}})])
+    monkeypatch.setattr(cli.random, "choice", lambda items: items[0])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.run,
+        [env.model_dump()["name"], "--rounds", "1", "--profile", "dev", "--no-llm"],
+        catch_exceptions=True,
+    )
+    assert result.exit_code != 0
+    assert "No bundled templates are available" in result.output

--- a/tests/test_small_coverage_edges.py
+++ b/tests/test_small_coverage_edges.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 import types
 


### PR DESCRIPTION
## Summary
- add high-yield unit and CLI tests across runner, data loading, decoder modules, and helper paths
- raise repository-wide non-integration coverage above 95%
- enforce a minimum coverage floor in the coverage report configuration

## Coverage Result
- `TOTAL 1523 75 95.08%`
- `fail_under = 95`

## What Changed
- added focused tests for `autoqec.runner.data`
- added focused tests for `autoqec.runner.runner`
- expanded coverage for `custom_fn_validator`
- expanded coverage for `gnn`, `neural_bp`, and shared module helpers
- added CLI helper tests for hidden/internal and error branches
- added small-gap coverage tests for flops, backend adapter, DSL family validation, machine state, and dispatch validation
- marked the `cli.autoqec` `__main__` guard as `no cover`

## Test Plan
- `pytest tests/test_runner_data.py tests/test_runner_core.py tests/test_cli_helpers.py tests/test_custom_fn_validator.py tests/test_gnn_module.py tests/test_neural_bp_module.py tests/test_small_coverage_edges.py -v`
- `pytest tests -m 'not integration' --cov=autoqec --cov=cli --cov-report=term -q`
- `make test`

Closes #23.

## Summary by Sourcery

Increase test coverage across runner, decoder modules, backend adapter, DSL validation, and CLI helpers, and enforce a repository-wide coverage threshold.

Build:
- Tighten coverage report configuration by setting precision to two decimals and enforcing a minimum 95% coverage threshold.

Tests:
- Add focused runner/core tests covering profiling, seeding, safety kill paths, success paths, and artifact variants.
- Add data-layer tests for code artifact loading and syndrome sampling for both Stim and parity-check environments.
- Expand decoder tests for custom function validation, GNN and MLP helpers, aggregation modes, and NeuralBP configuration branches.
- Add small edge-case tests for FLOPs estimation, backend adapter error handling, DSL family validation, GPU snapshotting, agent dispatch parsing, and subprocess orchestration.
- Add CLI helper tests for template loading failures, option parsing, internal round execution, environment creation, run command behaviors, and Pareto candidate selection.

Chores:
- Mark the CLI entry-point guard in cli.autoqec as excluded from coverage collection.