### PR TITLE
feat: add shared read-zulip skill

### DIFF
--- a/.claude/skills/read-zulip/SKILL.md
+++ b/.claude/skills/read-zulip/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: read-zulip
+description: Read Zulip stream/topic history for project context, summarize decisions, and recover requirements or action items. Use when task context may depend on prior Zulip discussion rather than only repository files.
+---
+
+# /read-zulip
+
+Read Zulip history with shared credentials, then turn the result into project
+context for the current task.
+
+## When to use
+
+- A task references hackathon discussion, prior design debate, or off-repo
+  decisions that probably live in Zulip.
+- Repository docs are insufficient and you need the original chat context.
+- The user asks you to inspect a specific Zulip stream, topic, or channel URL.
+
+## Auth resolution
+
+Use `scripts/read_zulip.py`. It resolves credentials in this order:
+
+1. `ZULIPRC`
+2. `~/.zuliprc`
+3. `~/.config/zulip/zuliprc`
+
+If a collaborator keeps credentials elsewhere, pass `--config /path/to/zuliprc`
+explicitly.
+
+Never commit Zulip credentials into this repository.
+
+## Repo defaults
+
+For this repository, start with:
+
+```bash
+python .claude/skills/read-zulip/scripts/read_zulip.py \
+  --url "https://quantum-info.zulipchat.com/#channels/591576/VibeYoga-Hackathon-QEC/general" \
+  --limit 20
+```
+
+If `general` returns no relevant messages, widen to the whole stream:
+
+```bash
+python .claude/skills/read-zulip/scripts/read_zulip.py \
+  --channel 591576 \
+  --limit 20
+```
+
+If you still need the active thread referenced by repo docs, check:
+
+```bash
+python .claude/skills/read-zulip/scripts/read_zulip.py \
+  --channel 591576 \
+  --topic "channel events" \
+  --limit 20
+```
+
+## Workflow
+
+1. Start with the narrowest stream/topic or URL that answers the question.
+2. Fetch a small window first, usually `--limit 20`.
+3. Expand only if the first pass is insufficient.
+4. Summarize decisions, requirements, blockers, and action items with message
+   IDs when they matter.
+
+## Useful commands
+
+Recent messages from a stream/topic:
+
+```bash
+python .claude/skills/read-zulip/scripts/read_zulip.py \
+  --channel "VibeYoga-Hackathon-QEC" \
+  --topic "channel events" \
+  --limit 20
+```
+
+Local substring filter over the fetched window:
+
+```bash
+python .claude/skills/read-zulip/scripts/read_zulip.py \
+  --channel 591576 \
+  --limit 100 \
+  --contains benchmark
+```
+
+Machine-readable output:
+
+```bash
+python .claude/skills/read-zulip/scripts/read_zulip.py \
+  --channel 591576 \
+  --limit 20 \
+  --format json
+```
+
+## Output rules
+
+- Default to plain-text output when you want to read and summarize.
+- Use `--format json` only when another tool/script will consume the result.
+- Keep summaries chronological when the discussion records changing decisions.
+- Quote only short snippets when direct wording matters.

--- a/.claude/skills/read-zulip/scripts/read_zulip.py
+++ b/.claude/skills/read-zulip/scripts/read_zulip.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Fetch Zulip messages using shared credentials resolved from common paths."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import configparser
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urlencode, urlparse
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class Credentials:
+    site: str
+    email: str
+    api_key: str
+    source: Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, help="Explicit zuliprc path.")
+    parser.add_argument(
+        "--url",
+        help="Zulip channel URL such as "
+        "https://.../#channels/591576/VibeYoga-Hackathon-QEC/general",
+    )
+    parser.add_argument("--channel", help="Channel/stream name or numeric id.")
+    parser.add_argument("--topic", help="Topic name.")
+    parser.add_argument("--site", help="Override site URL from zuliprc.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Number of recent messages to request before the anchor. Default: 20.",
+    )
+    parser.add_argument(
+        "--anchor",
+        default="newest",
+        help="Zulip anchor. Default: newest.",
+    )
+    parser.add_argument(
+        "--contains",
+        help="Case-insensitive substring filter applied after fetching.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print resolved credential source to stderr.",
+    )
+    return parser.parse_args()
+
+
+def candidate_config_paths(explicit: Path | None) -> Iterable[Path]:
+    if explicit is not None:
+        yield explicit.expanduser()
+        return
+
+    raw = os.environ.get("ZULIPRC")
+    if raw:
+        yield Path(raw).expanduser()
+    yield Path.home() / ".zuliprc"
+    yield Path.home() / ".config" / "zulip" / "zuliprc"
+
+
+def normalize_site(site: str) -> str:
+    site = site.strip()
+    if not site:
+        raise SystemExit("Empty site value in zuliprc.")
+    if "://" not in site:
+        site = f"https://{site}"
+    return site.rstrip("/")
+
+
+def load_credentials(explicit: Path | None, site_override: str | None) -> Credentials:
+    attempted: list[Path] = []
+    for candidate in candidate_config_paths(explicit):
+        attempted.append(candidate)
+        if not candidate.is_file():
+            continue
+        parser = configparser.RawConfigParser()
+        parser.read(candidate)
+        if not parser.has_section("api"):
+            continue
+        site = site_override or parser.get("api", "site", fallback="").strip()
+        email = parser.get("api", "email", fallback="").strip()
+        api_key = parser.get("api", "key", fallback="").strip()
+        if not site or not email or not api_key:
+            continue
+        return Credentials(
+            site=normalize_site(site),
+            email=email,
+            api_key=api_key,
+            source=candidate,
+        )
+    attempted_text = ", ".join(str(path) for path in attempted) or "<none>"
+    raise SystemExit(
+        "Unable to resolve Zulip credentials from: "
+        f"{attempted_text}. "
+        "Set ZULIPRC or create ~/.zuliprc or ~/.config/zulip/zuliprc."
+    )
+
+
+def parse_url_defaults(url: str) -> tuple[str | None, str | None]:
+    parsed = urlparse(url)
+    fragment = parsed.fragment.strip("/")
+    if not fragment:
+        return None, None
+    parts = fragment.split("/")
+    if len(parts) < 2 or parts[0] != "channels":
+        return None, None
+    channel = parts[1] or None
+    topic = unquote("/".join(parts[3:])).strip() or None if len(parts) > 3 else None
+    return channel, topic
+
+
+def build_narrow(channel: str | None, topic: str | None) -> list[dict[str, object]]:
+    narrow: list[dict[str, object]] = []
+    if channel:
+        operand: object = int(channel) if channel.isdigit() else channel
+        narrow.append({"operator": "channel", "operand": operand})
+    if topic:
+        narrow.append({"operator": "topic", "operand": topic})
+    return narrow
+
+
+def request_json(url: str, credentials: Credentials, params: dict[str, object]) -> dict:
+    query = urlencode(
+        {
+            key: json.dumps(value) if isinstance(value, (dict, list)) else value
+            for key, value in params.items()
+        }
+    )
+    auth = base64.b64encode(
+        f"{credentials.email}:{credentials.api_key}".encode("utf-8")
+    ).decode("ascii")
+    request = Request(
+        f"{url}?{query}",
+        headers={
+            "Authorization": f"Basic {auth}",
+            "User-Agent": "autoqec-read-zulip/1.0",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"Zulip API HTTP {exc.code}: {body}") from exc
+    except URLError as exc:
+        raise SystemExit(f"Unable to reach Zulip API: {exc}") from exc
+
+
+def fetch_messages(
+    credentials: Credentials,
+    channel: str | None,
+    topic: str | None,
+    limit: int,
+    anchor: str,
+) -> list[dict]:
+    if limit < 1:
+        raise SystemExit("--limit must be >= 1")
+    data = request_json(
+        f"{credentials.site}/api/v1/messages",
+        credentials,
+        {
+            "anchor": anchor,
+            "num_before": limit,
+            "num_after": 0,
+            "apply_markdown": "false",
+            "client_gravatar": "false",
+            "narrow": build_narrow(channel, topic),
+        },
+    )
+    if data.get("result") != "success":
+        raise SystemExit(f"Zulip API error: {data}")
+    return list(data.get("messages", []))
+
+
+def filter_messages(messages: Iterable[dict], needle: str | None) -> list[dict]:
+    items = list(messages)
+    if not needle:
+        return items
+    wanted = needle.casefold()
+    filtered = []
+    for message in items:
+        haystack = " ".join(
+            str(part)
+            for part in (
+                message.get("sender_full_name", ""),
+                message.get("display_recipient", ""),
+                message.get("subject", ""),
+                message.get("content", ""),
+            )
+        ).casefold()
+        if wanted in haystack:
+            filtered.append(message)
+    return filtered
+
+
+def iso_timestamp(value: int | float | None) -> str:
+    if value is None:
+        return ""
+    return (
+        datetime.fromtimestamp(value, tz=timezone.utc)
+        .astimezone()
+        .isoformat(timespec="seconds")
+    )
+
+
+def format_text(
+    messages: Iterable[dict],
+    credentials: Credentials,
+    channel: str | None,
+    topic: str | None,
+) -> str:
+    header = [
+        f"# source_config: {credentials.source}",
+        f"# site: {credentials.site}",
+        f"# channel: {channel or '<all>'}",
+        f"# topic: {topic or '<all>'}",
+        "",
+    ]
+    blocks = []
+    for message in messages:
+        blocks.extend(
+            [
+                (
+                    f"[{iso_timestamp(message.get('timestamp'))}] "
+                    f"{message.get('sender_full_name', '<unknown>')} "
+                    f"(id={message.get('id')}, topic={message.get('subject', '')})"
+                ),
+                str(message.get("content", "")).rstrip(),
+                "",
+            ]
+        )
+    return "\n".join(header + blocks).rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    url_channel, url_topic = parse_url_defaults(args.url) if args.url else (None, None)
+    channel = args.channel or url_channel
+    topic = args.topic or url_topic
+
+    credentials = load_credentials(args.config, args.site)
+    if args.print_config:
+        print(f"Using {credentials.source}", file=sys.stderr)
+
+    messages = fetch_messages(
+        credentials=credentials,
+        channel=channel,
+        topic=topic,
+        limit=args.limit,
+        anchor=args.anchor,
+    )
+    messages = filter_messages(messages, args.contains)
+
+    payload = {
+        "source_config": str(credentials.source),
+        "site": credentials.site,
+        "channel": channel,
+        "topic": topic,
+        "message_count": len(messages),
+        "messages": messages,
+    }
+    if args.format == "json":
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(format_text(messages, credentials, channel, topic), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,22 @@ Do not commit runtime artifacts, coverage outputs, or packaging byproducts.
   `docs/superpowers/plans/`.
 - Demo-specific instructions belong under `demos/<demo-name>/README.md`.
 
+## Zulip Context
+
+- When task context may depend on prior hackathon discussion, use the repo
+  skill at `.claude/skills/read-zulip/SKILL.md` before making assumptions.
+- Default Zulip context for this repository:
+  - site: `https://quantum-info.zulipchat.com`
+  - stream/channel: `VibeYoga-Hackathon-QEC` (`591576`)
+  - topic: `general`
+  - URL:
+    `https://quantum-info.zulipchat.com/#channels/591576/VibeYoga-Hackathon-QEC/general`
+  - If `general` returns no relevant messages, retry the same stream without a
+    topic narrow, then check the `channel events` topic.
+- Authentication should come from `ZULIPRC`, `~/.zuliprc`, or
+  `~/.config/zulip/zuliprc`.
+- Never store Zulip credentials in the repository.
+
 ## Commit Convention
 
 Use concise conventional-style commit prefixes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Orchestration writes **only** at the run root; the Runner writes **only** inside
 ## Skills & Subagents
 
 - `.claude/skills/autoqec-run/SKILL.md` — driver recipe for the full research loop. Invoked as `/autoqec-run`.
+- `.claude/skills/read-zulip/SKILL.md` — read hackathon Zulip history for off-repo context recovery. Invoked as `/read-zulip`.
 - `.claude/skills/add-env/SKILL.md` — wizard for adding a new environment YAML. Invoked as `/add-env`.
 - `.claude/agents/autoqec-ideator.md` — Ideator subagent prompt (consumes `fork_graph`, emits `fork_from` + `compose_mode`).
 - `.claude/agents/autoqec-coder.md` — Coder subagent prompt (aware that cwd is a worktree; emits `commit_message`).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/qualit527/qec-ai-decoder/actions/workflows/ci.yml/badge.svg)](https://github.com/qualit527/qec-ai-decoder/actions/workflows/ci.yml)
 [![testcov](https://codecov.io/github/qualit527/qec-ai-decoder/graph/badge.svg)](https://codecov.io/github/qualit527/qec-ai-decoder)
-[![API docs](https://img.shields.io/badge/API-docs-blue)](https://qualit527.github.io/qec-ai-decoder/)
+[![docs API](https://img.shields.io/badge/docs-API-blue)](https://qualit527.github.io/qec-ai-decoder/)
 
 AutoQEC is an LLM-agent-driven auto-research harness for discovering **neural predecoders** for quantum error-correcting codes. Given an environment triple `(code_spec, noise_model, constraints)`, the system runs 10–20 rounds of *hypothesis → DSL config → training → evaluation → analysis* and emits verified predecoder checkpoints on the accuracy–latency–parameters Pareto front.
 


### PR DESCRIPTION
Closes #27

## Summary
- add a repo-local `.claude/skills/read-zulip` skill so collaborators can inspect Zulip context from this project
- add a bundled `read_zulip.py` helper that resolves auth from `ZULIPRC`, `~/.zuliprc`, and `~/.config/zulip/zuliprc`
- document the shared skill in `AGENTS.md` and `CLAUDE.md`, including the default hackathon stream/topic workflow

## Verification
- `python -m py_compile .claude/skills/read-zulip/scripts/read_zulip.py`
- `python /home/tx/codex-home/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/read-zulip`
- `python .claude/skills/read-zulip/scripts/read_zulip.py --channel 591576 --limit 1 --format json`

## Summary by Sourcery

Add a shared read-zulip skill and helper script to fetch Zulip context for this project using shared credentials.

New Features:
- Introduce a repo-local read-zulip Claude skill for retrieving Zulip stream and topic history as project context.
- Add a reusable Python helper script that resolves Zulip credentials from standard locations and fetches messages with flexible query options.

Enhancements:
- Document default Zulip streams, topics, and usage workflow for this repository in agent and skill documentation, including authentication and safety guidance.