### PR TITLE
fix: demo smoke verification and artifact validation for issue 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,15 @@ runs/<YYYYMMDD-HHMMSS>/
 └── round_<N>/           # see below
 ```
 
-**Path B (`run_quick.sh` no-LLM)** — bare Runner output, no Analyst/Pareto:
+**Path B (`run_quick.sh` / `scripts/run_quick.py` no-LLM)** — bare Runner output with
+candidate-only bookkeeping, but no Analyst narrative or verified Pareto:
 
 ```
 runs/<YYYYMMDD-HHMMSS>/
 ├── history.jsonl        # one RoundMetrics record per round (no hypothesis,
 │                        # no verdict — no LLM ran)
 ├── history.json         # aggregate of above
+├── candidate_pareto.json # unverified non-dominated successful rounds
 └── round_<N>/           # see below
 ```
 
@@ -179,8 +181,9 @@ round_<N>/
   uses 64 val shots so Δ LER CI is wide — expect `Δ ≈ 0` with occasional
   lucky rounds. Prod profile numbers are the publishable ones.
 - **Candidate vs ignore**: Analyst flags `verdict = "candidate"` when Δ
-  LER is positive within CI. `pareto.json` only admits candidates;
-  ignored rounds still land in `history.jsonl` for debugging.
+  LER is positive within CI. LLM runs update `pareto.json`; no-LLM smoke
+  runs emit `candidate_pareto.json` as an unverified non-dominated summary.
+  Ignored rounds still land in `history.jsonl` for debugging.
 - **Compare to the baseline**: match `ler_predecoder` against the 1M-shot
   reference (0.01394). If your dev-profile `ler_plain_classical` sits
   around 0.015–0.020 that's the normal 64-shot noise.

--- a/demos/demo-1-surface-d5/README.md
+++ b/demos/demo-1-surface-d5/README.md
@@ -73,6 +73,20 @@ runs/<run_id>/
     └── metrics.json     # RoundMetrics (status, Δ LER, FLOPs, n_params, …)
 ```
 
+For the no-LLM smoke path, the run root is slightly different:
+
+```
+runs/<run_id>/
+├── history.jsonl
+├── history.json
+├── candidate_pareto.json   # unverified non-dominated successful rounds
+└── round_<N>/
+    ├── config.yaml
+    ├── train.log
+    ├── checkpoint.pt
+    └── metrics.json
+```
+
 Headline metric: compare `round_<N>/metrics.json::ler_predecoder` to
 the committed 1M-shot PyMatching reference at
 `demos/demo-1-surface-d5/expected_output/baseline_benchmark.json`

--- a/demos/demo-1-surface-d5/run_quick.sh
+++ b/demos/demo-1-surface-d5/run_quick.sh
@@ -20,4 +20,8 @@ echo ""
 echo "=== Demo 1 (no-LLM) complete ==="
 echo "Run dir: runs/$RUN_ID"
 echo "History: $(wc -l < runs/$RUN_ID/history.jsonl) rounds"
-[ -f "runs/$RUN_ID/pareto.json" ] && echo "Pareto:  $(cat runs/$RUN_ID/pareto.json)"
+if [ -f "runs/$RUN_ID/candidate_pareto.json" ]; then
+    echo "Candidate Pareto: $(cat runs/$RUN_ID/candidate_pareto.json)"
+else
+    echo "Candidate Pareto: (none yet)"
+fi

--- a/scripts/run_quick.py
+++ b/scripts/run_quick.py
@@ -92,11 +92,14 @@ def main() -> int:
         rounds = sum(1 for line in hist_path.read_text(encoding="utf-8").splitlines() if line.strip())
         print(f"History: {rounds} rounds")
 
-    pareto_path = run_dir / "pareto.json"
-    if pareto_path.exists():
-        print("Pareto:", json.loads(pareto_path.read_text(encoding="utf-8")))
+    candidate_pareto_path = run_dir / "candidate_pareto.json"
+    if candidate_pareto_path.exists():
+        print(
+            "Candidate Pareto:",
+            json.loads(candidate_pareto_path.read_text(encoding="utf-8")),
+        )
     else:
-        print("Pareto:  (none — --no-llm does not track pareto)")
+        print("Candidate Pareto:  (none yet)")
     return 0
 
 

--- a/tests/test_demo_smoke_contracts.py
+++ b/tests/test_demo_smoke_contracts.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import cli.autoqec as autoqec_cli
+from autoqec.runner.schema import RoundMetrics
+
+
+def _extract_result_payload(stdout: str) -> dict:
+    prefix = autoqec_cli.RESULT_PREFIX
+    payload_lines = [line for line in stdout.splitlines() if line.startswith(prefix)]
+    assert payload_lines, f"no result payload line found in stdout: {stdout!r}"
+    return json.loads(payload_lines[-1][len(prefix) :])
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "env_relpath",
+    [
+        "autoqec/envs/builtin/surface_d5_depol.yaml",
+        "autoqec/envs/builtin/bb72_depol.yaml",
+    ],
+)
+def test_no_llm_demo_smoke_writes_valid_artifact_contract(
+    tmp_path: Path,
+    env_relpath: str,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{env['PYTHONPATH']}" if env.get("PYTHONPATH") else str(repo_root)
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cli.autoqec",
+            "run",
+            str(repo_root / env_relpath),
+            "--rounds",
+            "1",
+            "--profile",
+            "dev",
+            "--no-llm",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding="utf-8",
+        env=env,
+    )
+
+    payload = _extract_result_payload(completed.stdout)
+    run_dir = Path(payload["run_dir"])
+    round_dir = run_dir / "round_1"
+
+    assert run_dir.exists()
+    assert not (run_dir / "log.md").exists()
+    assert not (run_dir / "pareto.json").exists()
+    assert (run_dir / "history.json").exists()
+    assert (run_dir / "history.jsonl").exists()
+    assert (run_dir / "candidate_pareto.json").exists()
+    assert payload["candidate_pareto_path"] == str(run_dir / "candidate_pareto.json")
+
+    history_json = json.loads((run_dir / "history.json").read_text(encoding="utf-8"))
+    history_jsonl = [
+        json.loads(line)
+        for line in (run_dir / "history.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(history_json) == 1
+    assert history_jsonl == history_json
+
+    history_row = history_jsonl[0]
+    assert history_row["round"] == 1
+    metrics_from_history = RoundMetrics.model_validate(history_row)
+    assert metrics_from_history.status == "ok"
+
+    assert (round_dir / "config.yaml").exists()
+    assert (round_dir / "train.log").exists()
+    assert (round_dir / "checkpoint.pt").exists()
+    assert (round_dir / "metrics.json").exists()
+
+    metrics = RoundMetrics.model_validate_json(
+        (round_dir / "metrics.json").read_text(encoding="utf-8")
+    )
+    assert metrics.status == "ok"
+    assert metrics.checkpoint_path == str(round_dir / "checkpoint.pt")
+    assert metrics.training_log_path == str(round_dir / "train.log")
+    assert Path(metrics.checkpoint_path).exists()
+    assert Path(metrics.training_log_path).exists()
+    assert metrics.n_params is not None and metrics.n_params > 0
+    assert metrics.flops_per_syndrome is not None and metrics.flops_per_syndrome > 0
+
+    candidate_pareto = json.loads((run_dir / "candidate_pareto.json").read_text(encoding="utf-8"))
+    assert isinstance(candidate_pareto, list)

--- a/tests/test_run_quick.py
+++ b/tests/test_run_quick.py
@@ -10,6 +10,7 @@ injection is structurally impossible even if validation were skipped.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -52,3 +53,36 @@ def test_validated_env_yaml_rejects_shell_metacharacter_path(tmp_path: Path) -> 
     hostile = tmp_path / "does-not-exist.yaml; rm -rf /"
     with pytest.raises(SystemExit, match="env_yaml not found"):
         _validated_env_yaml(str(hostile))
+
+
+def test_run_quick_reports_candidate_pareto_summary(monkeypatch, tmp_path: Path, capsys) -> None:
+    """The no-LLM CLI writes candidate_pareto.json, not pareto.json."""
+    from scripts import run_quick
+
+    env_yaml = tmp_path / "env.yaml"
+    env_yaml.write_text("name: smoke\n", encoding="utf-8")
+    run_dir = tmp_path / "runs" / "20260423-120000"
+    run_dir.mkdir(parents=True)
+    (run_dir / "history.jsonl").write_text('{"round": 1}\n', encoding="utf-8")
+    (run_dir / "candidate_pareto.json").write_text('[{"round": 1}]', encoding="utf-8")
+
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(run_quick, "_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_quick,
+        "_parse_args",
+        lambda: SimpleNamespace(env_yaml=str(env_yaml), rounds=1, profile="dev"),
+    )
+    monkeypatch.setattr(run_quick.subprocess, "run", fake_run)
+
+    assert run_quick.main() == 0
+
+    out = capsys.readouterr().out
+    assert "Candidate Pareto:" in out
+    assert "[{'round': 1}]" in out
+    assert "--no-llm" in calls[0][0]


### PR DESCRIPTION
## Summary by Sourcery

Align no-LLM demo smoke paths with the candidate Pareto artifact contract and verify it end-to-end.

New Features:
- Add an integration test that runs the no-LLM demo via the CLI and validates the full set of emitted artifacts and metrics.

Bug Fixes:
- Ensure the no-LLM quick-run path reports and validates candidate Pareto results from candidate_pareto.json instead of pareto.json.

Enhancements:
- Clarify documentation for no-LLM demo runs to describe candidate_pareto.json and distinguish it from verified Pareto output.
- Update the no-LLM demo shell script and Python helper to consistently surface candidate Pareto summaries in their console output.

Tests:
- Add coverage for run_quick no-LLM behavior to confirm it emits a candidate Pareto summary and passes the correct flags to the runner.