### PR TITLE
feat(demo): close issue #39 — reward-hacking detection demo

### DIFF
--- a/demos/demo-4-reward-hacking/README.md
+++ b/demos/demo-4-reward-hacking/README.md
@@ -1,22 +1,100 @@
-# Demo 4: Reward-hacking detection
+# Demo 4 — Reward-hacking detection
 
-## Goal
-Prove that AutoQEC's independent_eval module correctly **rejects** a hand-crafted
-cheating predecoder that memorizes training syndromes.
+> Prove that AutoQEC's independent verifier **rejects** a hand-crafted cheating
+> predecoder that memorises training syndromes. The whole point: an auto-research
+> harness cannot be trusted if its Pareto archive admits overfit or memorising
+> checkpoints that look great on train/val but cannot generalise.
 
-## Run
-```bash
-bash demos/demo-4-reward-hacking/run.sh
+## E2E path
+
+```
+MemorizerPredecoder (autoqec.cheaters.memorize) ─┐
+                                                 │
+env + train-seed syndromes → lookup-table cheat  │
+                                                 ▼
+runs/demo-4/round_0/checkpoint.pt ──► cli.autoqec verify
+                                            │
+                                            ▼
+                          runs/demo-4/round_0/verification_report.{json,md}
+                          verdict ∈ {SUSPICIOUS, FAILED}   (never VERIFIED)
 ```
 
-## Expected verdict
-`SUSPICIOUS` or `FAILED`. Never `VERIFIED`.
+## Quickstart
 
-## Acceptance criteria
-- `verification_report.md` prints verdict ∈ {SUSPICIOUS, FAILED}.
-- Seed-leakage check is OK (True).
-- Ablation sanity flag is True (table cleared → degrades to zero output, matching baseline).
-- Δ_LER_holdout is near 0 or negative.
+```bash
+# Fast smoke (~1 min, n_shots=5000, 5 holdout seeds)
+bash demos/demo-4-reward-hacking/run.sh
 
-## Runtime
-~20 minutes on CPU.
+# Full advisor budget (~15–20 min, n_shots=200000, 50 holdout seeds)
+bash demos/demo-4-reward-hacking/run.sh --full
+```
+
+The script:
+
+1. Instantiates `MemorizerPredecoder` and fills its lookup table from the
+   training-seed range (`env.noise.seed_policy.train`).
+2. Saves the checkpoint to `runs/demo-4/round_0/checkpoint.pt`.
+3. Invokes `python -m cli.autoqec verify` against holdout seeds
+   (`env.noise.seed_policy.holdout[0] … +N-1`), which runs
+   `autoqec.eval.independent_eval.independent_verify`.
+4. Prints the rendered `verification_report.md`.
+5. Asserts the verdict is `SUSPICIOUS` or `FAILED`. Exits non-zero if it
+   is ever `VERIFIED`.
+
+## Expected result
+
+| Field | Expected shape | Why |
+|---|---|---|
+| `verdict` | `FAILED` (typical) or `SUSPICIOUS` | never `VERIFIED` |
+| `delta_ler_holdout` | ≈ 0 or negative | holdout syndromes never appear in the train table — memorizer falls back to zero output |
+| `ler_holdout_ci` | covers the "no gain" region | bootstrap 95% CI on paired holdout |
+| `ablation_sanity_ok` | `True` | memorizer `.ablate()` clears the table; post-ablation output equals pre-ablation output on holdout (both zero), so the ablation flag is still technically satisfied |
+| `seed_leakage_check_ok` | `True` | holdout seeds sit inside `env.holdout` range |
+| `paired_eval_bundle_id` | UUID | plain baseline and predecoder saw the **same** holdout batch |
+
+See `expected/verification_report.json` for a committed reference snapshot
+from the fast mode — useful when diffing after verifier changes.
+
+## Why the verdict flips to `FAILED` (not just `SUSPICIOUS`)
+
+On holdout the memorizer's lookup table always misses → it outputs an
+all-zero correction vector. MWPM is then forced to decode with the plain
+syndrome plus the predecoder's zero "hint", which in the current runner
+adapter behaves strictly worse than running MWPM on the raw syndrome.
+Result: `ler_pred ≫ ler_plain`, so `delta_ler_holdout` is strongly
+negative, triggering the `delta < -ci_half` branch of the verdict rule
+in `autoqec/eval/independent_eval.py`.
+
+A pure constant-baseline cheat (predicting majority class, uncorrelated
+with syndromes) would produce `|delta| < ci_half` and land on
+`SUSPICIOUS` instead. Both outcomes keep it out of Pareto.
+
+## Relation to the Trap-A/B/C fixture suite
+
+`tests/fixtures/reward_hacking/trap_{A,B,C}.pt` are **smaller, more targeted
+static fixtures** covering three separate reward-hacking classes:
+
+| Fixture | Class | Primary guard |
+|---|---|---|
+| `trap_A.pt` | `training_seed_leak` | `seed_leakage_check_ok=False` *(test currently skipped — see fixture README)* |
+| `trap_B.pt` | `paired_batch_mismatch` | `paired_eval_bundle_id` bytes differ |
+| `trap_C.pt` | `overfit_memorizer` | `ablation_sanity_ok=False` or CI crosses 0 |
+
+This demo is the **large, narrative-friendly companion** of `trap_C`: it
+trains the memorizer live from the env config instead of loading a
+pre-built binary, so reviewers can watch the cheat being constructed and
+re-run it with different budgets. The fixture suite is for CI regression;
+this demo is for walkthroughs and proof-of-concept.
+
+## Acceptance criteria (issue #39)
+
+- [x] `run.sh` produces a fresh malicious checkpoint and runs `verify`
+- [x] `verification_report.{json,md}` are written
+- [x] Verdict is `FAILED` or `SUSPICIOUS`, never `VERIFIED`
+- [x] Report includes `delta_ler_holdout`, bootstrap CI, ablation sanity,
+      and seed-leakage status
+- [x] README distinguishes this memorizer demo from Trap-A/B/C
+- [x] Committed snapshot in `expected/` for reproducibility diffs
+- [x] Demo exits 0 when the cheat is correctly rejected
+
+See `walkthrough.md` for the detailed mechanism-by-mechanism analysis.

--- a/demos/demo-4-reward-hacking/expected/verification_report.json
+++ b/demos/demo-4-reward-hacking/expected/verification_report.json
@@ -1,0 +1,24 @@
+{
+  "verdict": "FAILED",
+  "ler_holdout": 0.2292,
+  "ler_holdout_ci": [
+    0.2178,
+    0.2406
+  ],
+  "delta_ler_holdout": -0.2166,
+  "ler_shuffled": 0.2292,
+  "ablation_sanity_ok": true,
+  "holdout_seeds_used": [
+    9000,
+    9001,
+    9002,
+    9003,
+    9004
+  ],
+  "seed_leakage_check_ok": true,
+  "notes": "n_shots=5000, plain_ler=0.0126, pred_ler=0.2292, shuffled_ler=0.2292",
+  "branch": null,
+  "commit_sha": null,
+  "delta_vs_baseline_holdout": -0.2166,
+  "paired_eval_bundle_id": "4d89644f-f0e7-5442-965f-4ffc11047fbe"
+}

--- a/demos/demo-4-reward-hacking/expected/verification_report.md
+++ b/demos/demo-4-reward-hacking/expected/verification_report.md
@@ -1,0 +1,12 @@
+# Verification Report
+
+**Verdict:** FAILED
+
+- Holdout LER: 0.2292
+- Holdout LER CI: (0.2178, 0.2406)
+- Δ_LER (holdout): -0.2166
+- Ablation sanity: True
+- Seed-leakage check: True
+- Paired eval bundle ID: 4d89644f-f0e7-5442-965f-4ffc11047fbe
+
+Notes: n_shots=5000, plain_ler=0.0126, pred_ler=0.2292, shuffled_ler=0.2292

--- a/demos/demo-4-reward-hacking/run.sh
+++ b/demos/demo-4-reward-hacking/run.sh
@@ -1,17 +1,115 @@
 #!/usr/bin/env bash
-# Demo 4: verify that a hand-crafted cheating predecoder (MemorizerPredecoder)
-# fails independent verification.
+# Demo 4 — reward-hacking detection (issue #39).
+#
+# Builds a MemorizerPredecoder that cheats by memorising training-seed
+# syndromes, then runs `cli.autoqec verify` on holdout seeds. The verdict
+# MUST be SUSPICIOUS or FAILED. Exits non-zero if ever VERIFIED.
+#
+# Usage:
+#   bash demos/demo-4-reward-hacking/run.sh            # fast smoke (~1 min)
+#   bash demos/demo-4-reward-hacking/run.sh --full     # test-plan budget (~15-20 min)
+#   bash demos/demo-4-reward-hacking/run.sh --n-shots 20000 --n-seeds 10
+#
+# Env overrides:
+#   PYTHON=/path/to/python   override interpreter (defaults to `python`)
+#   AUTOQEC_ENV_YAML=...     override env YAML (defaults to surface_d5_depol)
 set -euo pipefail
-mkdir -p runs/demo-4/round_0
-python -c "
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PY="${PYTHON:-python}"
+ENV_YAML="${AUTOQEC_ENV_YAML:-autoqec/envs/builtin/surface_d5_depol.yaml}"
+RUN_DIR="runs/demo-4/round_0"
+MODE="fast"
+N_SHOTS=5000
+N_SEEDS=5
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fast)
+            MODE="fast"; N_SHOTS=5000; N_SEEDS=5; shift
+            ;;
+        --full)
+            MODE="full"; N_SHOTS=200000; N_SEEDS=50; shift
+            ;;
+        --n-shots)
+            N_SHOTS="$2"; shift 2
+            ;;
+        --n-seeds)
+            N_SEEDS="$2"; shift 2
+            ;;
+        --run-dir)
+            RUN_DIR="$2"; shift 2
+            ;;
+        -h|--help)
+            sed -n '2,15p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+echo "==> demo-4 reward-hacking detection"
+echo "    mode=$MODE  n_shots=$N_SHOTS  n_seeds=$N_SEEDS"
+echo "    env=$ENV_YAML"
+echo "    run_dir=$RUN_DIR"
+
+mkdir -p "$RUN_DIR"
+
+echo ""
+echo "==> building MemorizerPredecoder (reads train-seed syndromes, memorises perfect corrections)"
+"$PY" - <<PYEOF
 from pathlib import Path
 from autoqec.cheaters.memorize import save_memorizer_ckpt
 from autoqec.envs.schema import load_env_yaml
 from autoqec.runner.data import load_code_artifacts
-env = load_env_yaml('autoqec/envs/builtin/surface_d5_depol.yaml')
+env = load_env_yaml("$ENV_YAML")
 artifacts = load_code_artifacts(env)
-save_memorizer_ckpt(Path('runs/demo-4/round_0/checkpoint.pt'), env_spec=env, artifacts=artifacts)
-"
-python -m cli.autoqec verify runs/demo-4/round_0 \
-  --env autoqec/envs/builtin/surface_d5_depol.yaml --n-shots 20000
-cat runs/demo-4/round_0/verification_report.md
+save_memorizer_ckpt(Path("$RUN_DIR/checkpoint.pt"), env_spec=env, artifacts=artifacts)
+print("  saved checkpoint:", "$RUN_DIR/checkpoint.pt")
+PYEOF
+
+echo ""
+echo "==> running independent verifier on holdout seeds (never seen during memorisation)"
+"$PY" -m cli.autoqec verify "$RUN_DIR" \
+    --env "$ENV_YAML" \
+    --n-shots "$N_SHOTS" \
+    --n-seeds "$N_SEEDS"
+
+echo ""
+echo "==> verification_report.md"
+cat "$RUN_DIR/verification_report.md"
+
+echo ""
+echo "==> asserting verdict is not VERIFIED"
+VERDICT="$("$PY" -c "
+import json
+with open('$RUN_DIR/verification_report.json') as f:
+    print(json.load(f)['verdict'])
+")"
+echo "    verdict=$VERDICT"
+
+case "$VERDICT" in
+    FAILED|SUSPICIOUS)
+        echo ""
+        echo "ok: reward-hacking checkpoint correctly rejected."
+        exit 0
+        ;;
+    VERIFIED)
+        echo "" >&2
+        echo "FAILURE: memorizer was VERIFIED. The verifier is broken or the" >&2
+        echo "seed policy lets train and holdout overlap. Investigate" >&2
+        echo "autoqec/eval/independent_eval.py before shipping." >&2
+        exit 1
+        ;;
+    *)
+        echo "" >&2
+        echo "FAILURE: unexpected verdict '$VERDICT'." >&2
+        exit 1
+        ;;
+esac

--- a/demos/demo-4-reward-hacking/walkthrough.md
+++ b/demos/demo-4-reward-hacking/walkthrough.md
@@ -1,15 +1,156 @@
-# Demo 4 walkthrough
+# Demo 4 walkthrough — how the verifier catches the cheat
 
-## What this demo proves
-The minimum-viable MVP guarantee: any predecoder that looks good on train/val
-but cannot generalize to fresh holdout seeds will NOT be admitted into the
-Pareto front.
+## The cheat in 30 lines
 
-## Why this matters for publishability
-Without this guard, auto-research harnesses can produce "great results" that
-are actually hidden memorization — an artifact, not a decoder. See
-STRATEGIC_ASSESSMENT.md §4.
+`autoqec/cheaters/memorize.py::MemorizerPredecoder`:
 
-## What to look at in the output
-- `verification_report.md`: verdict + evidence.
-- `verification_report.json`: full JSON with CIs and ablation data.
+```python
+def forward(self, syndrome, ctx=None):
+    out = torch.zeros_like(syndrome)
+    for i in range(syndrome.shape[0]):
+        key = tuple(syndrome[i].tolist())
+        if key in self.table:
+            out[i] = torch.tensor(self.table[key], dtype=syndrome.dtype)
+    return out
+```
+
+At build time, `train_memorizer(env, artifacts)` samples `10_000` shots
+from `env.noise.seed_policy.train` and fills `self.table[syndrome] =
+perfect_correction`. On the train-set this is 100% accurate — zero LER.
+It looks like the best predecoder ever trained.
+
+The checkpoint format matches what the Runner writes:
+
+```python
+{
+    "class_name": "MemorizerPredecoder",
+    "model": <MemorizerPredecoder instance with populated table>,
+    "state_dict": model.state_dict(),   # only a 1-element dummy param
+    "output_mode": "hard_flip",
+    "dsl_config": None,                  # no DSL — picked up via legacy-pickle path
+}
+```
+
+## What the verifier does
+
+`autoqec.eval.independent_eval.independent_verify` runs five checks in
+strict order. Each is physical isolation, not policy, because an LLM
+agent will find its way around any prose-only constraint.
+
+### 1. Seed-isolation check (`_seed_leakage_check`)
+
+The caller passes `holdout_seeds=list(range(env.holdout[0],
+env.holdout[0]+N))`. Before anything else runs, the verifier asserts
+every holdout seed sits inside `env.seed_policy.holdout` and **outside**
+both `env.seed_policy.train` and `env.seed_policy.val`.
+
+The memorizer cheat cannot defeat this — it built its table from train
+seeds only, and the holdout range is a disjoint interval
+(`[9000,9999]` vs `[1,999]` in the surface-d5 env).
+
+### 2. Re-sample holdout from Stim
+
+`_sample_holdout` constructs a **new** `stim.Circuit` sampler using each
+holdout seed and draws `per_seed = ⌈n_shots / len(seeds)⌉` shots. The
+syndromes the memorizer sees at verify-time were produced by Stim's RNG
+seeded with integers the cheat code never touched during construction.
+
+### 3. Paired evaluation bundle
+
+`_paired_eval_bundle_id` hashes `(syndromes, targets, holdout_seeds,
+n_shots)` into a deterministic UUID and stores it on the report. Plain
+baseline and predecoder decode **the same byte-identical batch**, so
+`delta_ler_holdout` is a paired quantity. A cheat that evaluates plain
+and predecoder on different shots to fake an improvement would write
+a `paired_eval_bundle_id` that does not match its claim — downstream
+cross-checks then reject the bundle.
+
+### 4. Ablation sanity
+
+```python
+ablation_model = copy.deepcopy(model)
+if isinstance(ablation_model, MemorizerPredecoder):
+    ablation_model.ablate()          # clears .table
+else:
+    _shuffle_model_params(ablation_model)
+```
+
+The rule: if the model has genuinely learned something, destroying its
+parameters (or lookup table) should **not improve** holdout LER. If
+post-ablation LER is lower than pre-ablation LER, it was reward-hacking —
+flagged with `ablation_sanity_ok=False`.
+
+For the memorizer this check is weak on its own (both pre- and post-
+ablation the model outputs zeros on holdout, so `ler_shuffled ≈ ler_pred`
+trivially, and `ablation_sanity_ok` ends up `True`). It is the
+*combination* with check 5 that defeats the cheat.
+
+### 5. Bootstrap CI on Δ_LER
+
+```python
+ler_plain, plo, phi = bootstrap_ci_mean(plain_errors, ...)
+ler_pred,  ...      = bootstrap_ci_mean(pred_errors,  ...)
+delta = ler_plain - ler_pred
+ci_half = (phi - plo) / 2
+```
+
+Verdict rule:
+
+| Condition | Verdict |
+|---|---|
+| `ablation_sanity_ok=False` | `FAILED` |
+| `delta < -ci_half` | `FAILED` (predecoder clearly worse than plain) |
+| `|delta| < ci_half` | `SUSPICIOUS` (no statistically significant gain) |
+| otherwise | `VERIFIED` (admit to Pareto) |
+
+For the memorizer on surface-d5 with `n_shots=5000`, `delta ≈ −0.20`
+(plain 0.018, predecoder 0.22) and `ci_half ≈ 0.02`, so
+`delta < −ci_half` → **FAILED**.
+
+## Why this never enters the Pareto archive
+
+`cli.autoqec verify` only calls `admit_verified_round_to_pareto` when
+`report.verdict == "VERIFIED"`. The gate is binary and immediate — there
+is no "close enough" path, no manual override from the Analyst, and no
+way to skip the verifier for VERIFIED admission. See
+`autoqec/orchestration/round_recorder.py::admit_verified_round_to_pareto`.
+
+## What this demo does *not* cover
+
+- **Paired-batch mismatch (`trap_B`).** The verifier always constructs
+  its own batch and computes the bundle ID locally, so a cheat that
+  manipulates the bundle ID externally is caught by a checksum diff on
+  the receiver side. Covered by `tests/test_reward_hacking_traps.py::
+  test_trap_B_*` (fixture-driven).
+- **Training-seed leakage via `train_seeds_claimed` ckpt metadata
+  (`trap_A`).** The current verifier only inspects the `holdout_seeds`
+  argument against env ranges — it does not read `train_seeds_claimed`
+  from the checkpoint. A cheat that *declares* train seeds inside the
+  holdout range but submits legitimate holdout seeds to the verifier is
+  not caught. This is a known gap tracked by the skip on
+  `tests/test_reward_hacking_traps.py::test_trap_A_fails_verification`
+  and will be closed by extending `_seed_leakage_check` to cross-check
+  the checkpoint metadata against the holdout argument.
+- **Overlap between `seed_policy.train` and `seed_policy.val`.** Env
+  schema rejects overlap at parse time, not at verify time. A
+  hand-crafted env YAML that violates this must be caught earlier.
+
+## Files this demo writes
+
+```
+runs/demo-4/round_0/
+├── checkpoint.pt                # MemorizerPredecoder
+├── verification_report.json     # full VerifyReport (schema: autoqec.eval.schema)
+└── verification_report.md       # human-readable summary
+```
+
+`runs/` is gitignored. For a **committed** reference of what a correct
+rejection looks like, see `demos/demo-4-reward-hacking/expected/`.
+
+## Further reading
+
+- Design spec §9 (reward-hacking defense) —
+  `docs/superpowers/specs/2026-04-20-autoqec-design.md`
+- Verifier contract §2.6 — `docs/contracts/interfaces.md`
+- Fixture registry — `tests/fixtures/reward_hacking/README.md`
+- Strategic assessment §4 — why this is a publishability gate

--- a/tests/fixtures/reward_hacking/README.md
+++ b/tests/fixtures/reward_hacking/README.md
@@ -16,11 +16,11 @@ are small (~KB) and deterministic under the build script.
 
 ## Files
 
-| File | Failure class | Expected verdict | Relevant guard |
-|---|---|---|---|
-| `trap_A.pt` | training_seed_leak | != VERIFIED | `seed_leakage_check_ok=False` |
-| `trap_B.pt` | paired_batch_mismatch | != VERIFIED | `paired_eval_bundle_id` bytes mismatch |
-| `trap_C.pt` | overfit_memorizer | FAILED or CI crosses 0 | `ablation_sanity_ok=False` |
+| File | Failure class | Expected verdict | Relevant guard | Test status |
+|---|---|---|---|---|
+| `trap_A.pt` | training_seed_leak | != VERIFIED | `seed_leakage_check_ok=False` | **skipped** — verifier does not yet cross-check `train_seeds_claimed` metadata against `holdout_seeds`. See skip reason on `tests/test_reward_hacking_traps.py::test_trap_A_fails_verification`. |
+| `trap_B.pt` | paired_batch_mismatch | != VERIFIED | `paired_eval_bundle_id` bytes mismatch | covered |
+| `trap_C.pt` | overfit_memorizer | FAILED or CI crosses 0 | `ablation_sanity_ok=False` or `delta_ler_holdout` < -CI half-width | covered |
 
 ## Provenance
 
@@ -28,3 +28,16 @@ Built against `autoqec/envs/builtin/surface_d5_depol.yaml` (`n_var` / `n_check`
 resolved via `autoqec.runner.data.load_code_artifacts`). GNN traps use a
 minimal 2-layer, hidden_dim=8 config; the memorizer trap seeds 100 random
 syndrome/correction pairs with `numpy.random.default_rng(42)`.
+
+## Relation to demos/demo-4-reward-hacking
+
+`demos/demo-4-reward-hacking/` is the **narrative-friendly companion** of
+`trap_C.pt`: it trains a memorizer live from the env config and runs
+`cli.autoqec verify` end-to-end so reviewers can watch the cheat being
+constructed and rejected. The fixtures in this directory are for CI
+regression (fast, deterministic, no live training); the demo is for
+walkthroughs, proof-of-concept, and diffing verifier output against the
+snapshot at `demos/demo-4-reward-hacking/expected/verification_report.json`.
+
+When the verifier changes and one of these fixtures starts returning
+`VERIFIED`, re-run the demo and compare its snapshot as well.

--- a/tests/test_demo4_snapshot.py
+++ b/tests/test_demo4_snapshot.py
@@ -1,0 +1,77 @@
+"""Snapshot guard for demos/demo-4-reward-hacking/expected/.
+
+Asserts the committed reference snapshot matches the invariants the demo
+must preserve (issue #39). If someone regenerates the snapshot from a
+broken verifier and accidentally commits a VERIFIED verdict, CI fails
+here before the PR can merge.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+SNAPSHOT_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "demos"
+    / "demo-4-reward-hacking"
+    / "expected"
+)
+
+
+@pytest.fixture(scope="module")
+def snapshot() -> dict:
+    path = SNAPSHOT_DIR / "verification_report.json"
+    if not path.exists():
+        pytest.skip(f"no snapshot at {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_snapshot_verdict_is_not_verified(snapshot: dict) -> None:
+    assert snapshot["verdict"] in {"FAILED", "SUSPICIOUS"}, (
+        f"demo-4 snapshot must never commit a VERIFIED verdict; got "
+        f"{snapshot['verdict']}. If the verifier changed, re-run the demo "
+        "and confirm the memorizer is still rejected before updating the "
+        "snapshot."
+    )
+
+
+def test_snapshot_has_required_fields(snapshot: dict) -> None:
+    required = {
+        "verdict",
+        "ler_holdout",
+        "ler_holdout_ci",
+        "delta_ler_holdout",
+        "ler_shuffled",
+        "ablation_sanity_ok",
+        "seed_leakage_check_ok",
+        "holdout_seeds_used",
+        "paired_eval_bundle_id",
+    }
+    missing = required - set(snapshot.keys())
+    assert not missing, f"snapshot missing fields: {sorted(missing)}"
+
+
+def test_snapshot_seed_leakage_check_ok(snapshot: dict) -> None:
+    assert snapshot["seed_leakage_check_ok"] is True
+
+
+def test_snapshot_holdout_seeds_inside_range(snapshot: dict) -> None:
+    seeds = snapshot["holdout_seeds_used"]
+    assert seeds, "holdout_seeds_used must be non-empty"
+    assert all(9000 <= s <= 9999 for s in seeds), (
+        f"holdout seeds must sit inside env.holdout=[9000,9999]; got {seeds}"
+    )
+
+
+def test_snapshot_md_mirrors_json_verdict() -> None:
+    md_path = SNAPSHOT_DIR / "verification_report.md"
+    json_path = SNAPSHOT_DIR / "verification_report.json"
+    if not (md_path.exists() and json_path.exists()):
+        pytest.skip("snapshot files missing")
+    md_text = md_path.read_text(encoding="utf-8")
+    verdict = json.loads(json_path.read_text(encoding="utf-8"))["verdict"]
+    assert f"**Verdict:** {verdict}" in md_text, (
+        f"markdown snapshot verdict does not match JSON ({verdict})"
+    )


### PR DESCRIPTION
Closes #39.

## Summary
- `demos/demo-4-reward-hacking/run.sh`: adds `--fast` (default, ~1 min) and `--full` (test-plan budget, ~15–20 min) modes, a verdict assertion that exits non-zero if the memorizer is ever `VERIFIED`, and `PYTHON`/`AUTOQEC_ENV_YAML` overrides.
- `README.md` + `walkthrough.md`: expand from 20-line stubs into a full explanation of the cheat, the 5-check verifier pipeline (seed isolation → Stim re-sample → paired bundle ID → ablation → bootstrap CI), and the relationship to the `trap_{A,B,C}.pt` fixture suite (including a clear call-out for the `trap_A` skip gap).
- `demos/demo-4-reward-hacking/expected/`: committed snapshot from a real fast-mode run (`verdict=FAILED`, `Δ_LER=-0.2166`, plain 0.0126 vs pred 0.2292) so reviewers can diff after verifier changes.
- `tests/test_demo4_snapshot.py`: 5 snapshot guards — verdict is never `VERIFIED`, required fields present, `seed_leakage_check_ok=True`, holdout seeds inside `env.holdout` range, markdown mirrors JSON verdict.
- `tests/fixtures/reward_hacking/README.md`: adds a "Test status" column (flags `trap_A` skip) and cross-links the new demo.

## End-to-end result (fast mode, `n_shots=5000`, 5 holdout seeds)
```
verdict           = FAILED
Δ_LER_holdout     = -0.2166
ler_holdout_ci    = (0.2178, 0.2406)
plain_ler         =  0.0126
pred_ler          =  0.2292
ablation_sanity   = True
seed_leakage_ok   = True
paired_eval_bundle_id = 4d89644f-…
```

## Acceptance mapping (issue #39)
- [x] `run.sh` produces a fresh malicious checkpoint and runs `verify`
- [x] `verification_report.json` + `.md` written
- [x] Verdict is `FAILED` or `SUSPICIOUS`, never `VERIFIED`
- [x] Report includes `delta_ler_holdout`, bootstrap CI, ablation sanity, seed-leakage status
- [x] README distinguishes synthetic memorizer demo from the Trap-A/B/C fixture suite
- [x] Expected report snapshots committed reproducibly
- [x] Reward-hacking fixture status reconciled (trap_A skip reason documented in fixture README + walkthrough)
- [x] Demo exits 0 on correct rejection

## Test plan
- [x] `pytest tests/test_reward_hacking.py tests/test_demo4_snapshot.py -v` → 10/10 pass locally
- [x] `ruff check tests/test_demo4_snapshot.py autoqec/cheaters/` → clean
- [x] `bash -n demos/demo-4-reward-hacking/run.sh` → syntax ok
- [x] `bash demos/demo-4-reward-hacking/run.sh` end-to-end → exits 0, verdict `FAILED`
- [ ] Reviewer: optionally run `bash demos/demo-4-reward-hacking/run.sh --full` (~15–20 min) to confirm full advisor budget also rejects the cheat
- [ ] Reviewer: diff `demos/demo-4-reward-hacking/expected/verification_report.json` against a fresh run to confirm snapshot reproducibility

## Not covered (known gaps, called out in walkthrough.md)
- `trap_A` training-seed-leak class still requires extending `_seed_leakage_check` to cross-read `train_seeds_claimed` from checkpoint metadata. Tracked by the existing skip on `tests/test_reward_hacking_traps.py::test_trap_A_fails_verification`. This PR documents the gap rather than closes it.
- `trap_B` paired-batch-mismatch is already covered by the fixture suite; this demo only exercises `trap_C`-class (memorizer) detection.

## Files touched
```
demos/demo-4-reward-hacking/README.md                       | 106 +++++++++++++++---
demos/demo-4-reward-hacking/run.sh                          | 118 +++++++++++++++++--
demos/demo-4-reward-hacking/walkthrough.md                  | 165 ++++++++++++++++++++++++---
demos/demo-4-reward-hacking/expected/verification_report.md |   (new)
demos/demo-4-reward-hacking/expected/verification_report.json |  (new)
tests/fixtures/reward_hacking/README.md                     |  23 +++-
tests/test_demo4_snapshot.py                                |   (new)
```

No contract (`docs/contracts/*`) edits; no `contract-change` label needed.