### PR TITLE
feat(demo): failure diagnosis and recovery walkthrough for issue 40 and 41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ datasets/
 # IDE
 .idea/
 .vscode/
+.worktrees/
 *.swp
 
 # OS

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ datasets/
 # IDE
 .idea/
 .vscode/
-.worktrees/
 *.swp
 
 # OS

--- a/cli/autoqec.py
+++ b/cli/autoqec.py
@@ -4,6 +4,7 @@ from importlib import resources
 import json
 import os
 import random
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -33,6 +34,12 @@ def main() -> None:
 
 
 RESULT_PREFIX = "AUTOQEC_RESULT_JSON="
+_OOM_RE = re.compile(r"(out of memory|(?<![a-z])oom(?![a-z])|(?<![a-z])vram(?![a-z]))", re.IGNORECASE)
+_NAN_RE = re.compile(r"(?<![a-z])nan(?![a-z])", re.IGNORECASE)
+_COMPILE_RE = re.compile(
+    r"(compile_error|validation failed|must be >=|must be <=|valueerror|validationerror)",
+    re.IGNORECASE,
+)
 
 
 def _read_text_if_exists(path: Path) -> str:
@@ -50,22 +57,31 @@ def _first_matching_line(candidates: list[str], predicate) -> str | None:
     return None
 
 
+def _round_sort_key(path: Path) -> tuple[int, int | str]:
+    suffix = path.name.removeprefix("round_")
+    if suffix.isdigit():
+        return (0, int(suffix))
+    return (1, path.name)
+
+
 def _diagnose_failure_signature(metrics: dict | None, train_log_text: str, config_text: str) -> tuple[str, list[str]]:
     status_reason = ""
+    status = ""
     if metrics is not None:
         status_reason = str(metrics.get("status_reason") or "")
+        status = str(metrics.get("status") or "").lower()
     candidates = [status_reason, train_log_text, config_text]
 
     oom_signal = _first_matching_line(
         candidates,
-        lambda line: "out of memory" in line or "oom" in line or "vram" in line,
+        lambda line: bool(_OOM_RE.search(line)),
     )
     if oom_signal is not None:
         return "oom", [oom_signal]
 
     nan_signal = _first_matching_line(
         candidates,
-        lambda line: "nan" in line,
+        lambda line: bool(_NAN_RE.search(line)),
     )
     if nan_signal is not None:
         return "nan_loss", [nan_signal]
@@ -77,14 +93,16 @@ def _diagnose_failure_signature(metrics: dict | None, train_log_text: str, confi
     if degenerate_signal is not None:
         return "degenerate_p_zero", [degenerate_signal]
 
+    if status == "compile_error":
+        compile_signal = _first_matching_line(
+            candidates,
+            lambda line: bool(_COMPILE_RE.search(line)),
+        )
+        return "compile_error", [compile_signal or status_reason or status]
+
     compile_signal = _first_matching_line(
         candidates,
-        lambda line: (
-            "compile_error" in line
-            or "validation failed" in line
-            or "must be >=" in line
-            or "pydantic" in line
-        ),
+        lambda line: bool(_COMPILE_RE.search(line)),
     )
     if compile_signal is not None:
         return "compile_error", [compile_signal]
@@ -583,7 +601,7 @@ def diagnose(run_dir: str) -> None:
     if (rd / "metrics.json").exists() or (rd / "train.log").exists():
         target = rd
     else:
-        round_dirs = sorted(rd.glob("round_*"))
+        round_dirs = sorted(rd.glob("round_*"), key=_round_sort_key)
         if not round_dirs:
             click.echo("No round dirs found and no metrics in given path")
             return

--- a/cli/autoqec.py
+++ b/cli/autoqec.py
@@ -77,6 +77,18 @@ def _diagnose_failure_signature(metrics: dict | None, train_log_text: str, confi
     if degenerate_signal is not None:
         return "degenerate_p_zero", [degenerate_signal]
 
+    compile_signal = _first_matching_line(
+        candidates,
+        lambda line: (
+            "compile_error" in line
+            or "validation failed" in line
+            or "must be >=" in line
+            or "pydantic" in line
+        ),
+    )
+    if compile_signal is not None:
+        return "compile_error", [compile_signal]
+
     return "unknown", []
 def _write_round_metrics(round_dir: str, metrics: RoundMetrics) -> RoundMetrics:
     metrics_path = Path(round_dir).resolve() / "metrics.json"

--- a/demos/demo-5-failure-recovery/README.md
+++ b/demos/demo-5-failure-recovery/README.md
@@ -1,18 +1,48 @@
-# Demo 5: Failure recovery
+# Demo 5: Failure Diagnosis and Recovery Walkthrough
 
 ## Goal
-Show that `/diagnose-failure` reads broken-run state and recommends a fix.
+
+Show that AutoQEC can read a broken run directory, identify the failure class, and recommend a fix **without applying changes autonomously**.
 
 ## Run
+
 ```bash
 bash demos/demo-5-failure-recovery/run.sh
 ```
 
-## Acceptance
-- CLI prints structured round stats.
-- The LLM skill layer (invoked via `/diagnose-failure runs/demo-5/`) would produce
-  a `diagnosis.md` identifying `hidden_dim: -1` as the root cause and suggesting
-  `hidden_dim: 32`.
+## What it covers
+
+| Round | Failure mode   | Root cause                                        |
+|-------|----------------|---------------------------------------------------|
+| 0     | compile_error  | `hidden_dim: -1` fails pydantic validation        |
+| 1     | NaN loss       | Learning rate too high (10.0) causes NaN cascade  |
+| 2     | OOM            | Model too large for available VRAM                |
+
+## CLI commands used
+
+```bash
+# Diagnose a specific round
+python -m cli.autoqec diagnose runs/demo-5/round_0
+
+# Skill-layer walkthrough
+/diagnose-failure runs/demo-5/round_0
+
+# Diagnose a run directory (auto-selects latest round, round_2)
+python -m cli.autoqec diagnose runs/demo-5
+```
+
+## Acceptance criteria
+
+- [x] Demo exits 0
+- [x] `bad_config.yaml` contains a clear schema failure (`hidden_dim: -1`)
+- [x] `run.sh` creates synthetic failed `round_0`, `round_1`, `round_2` directories
+- [x] CLI `diagnose` outputs structured JSON with path, root_cause, signals, and artifact flags
+- [x] CLI `diagnose` identifies the latest round when passed a run directory
+- [x] CLI `diagnose` handles direct round-dir input
+- [x] `/diagnose-failure` skill contract is exercised against the synthetic run, and `diagnosis.md` is written per round with root cause, evidence citations, and patched YAML
+- [x] Walkthrough states the system does not apply fixes automatically
+- [x] Covers three failure modes: compile error, NaN loss, OOM
 
 ## Runtime
-~1 minute.
+
+~30 seconds (no training, no GPU, no LLM calls).

--- a/demos/demo-5-failure-recovery/bad_config.yaml
+++ b/demos/demo-5-failure-recovery/bad_config.yaml
@@ -1,20 +1,19 @@
 # demos/demo-5-failure-recovery/bad_config.yaml
 # Intentionally malformed: hidden_dim is negative (pydantic rejects).
-predecoder:
-  type: gnn
-  output_mode: soft_priors
-  gnn:
-    layers: 3
-    hidden_dim: -1           # <-- invalid
-    message_fn: mlp
-    aggregation: sum
-    normalization: layer
-    residual: false
-    edge_features: [syndrome_bit]
-  head: linear
-  training:
-    learning_rate: 1.0e-3
-    batch_size: 64
-    epochs: 1
-    loss: bce
-    profile: dev
+type: gnn
+output_mode: soft_priors
+gnn:
+  layers: 3
+  hidden_dim: -1           # <-- invalid: must be >= 4
+  message_fn: mlp
+  aggregation: sum
+  normalization: layer
+  residual: false
+  edge_features: [syndrome_bit]
+head: linear
+training:
+  learning_rate: 1.0e-3
+  batch_size: 64
+  epochs: 1
+  loss: bce
+  profile: dev

--- a/demos/demo-5-failure-recovery/generate_diagnosis.py
+++ b/demos/demo-5-failure-recovery/generate_diagnosis.py
@@ -2,8 +2,17 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
+
+
+_OOM_RE = re.compile(r"(out of memory|(?<![a-z])oom(?![a-z])|(?<![a-z])vram(?![a-z]))", re.IGNORECASE)
+_NAN_RE = re.compile(r"(?<![a-z])nan(?![a-z])", re.IGNORECASE)
+_COMPILE_RE = re.compile(
+    r"(compile_error|validation failed|must be >=|must be <=|valueerror|validationerror)",
+    re.IGNORECASE,
+)
 
 
 def _line_number(text: str, needle: str) -> int | None:
@@ -11,6 +20,13 @@ def _line_number(text: str, needle: str) -> int | None:
         if needle in line:
             return idx
     return None
+
+
+def _round_sort_key(path: Path) -> tuple[int, int | str]:
+    suffix = path.name.removeprefix("round_")
+    if suffix.isdigit():
+        return (0, int(suffix))
+    return (1, path.name)
 
 
 def generate(round_dir: Path) -> None:
@@ -28,21 +44,21 @@ def generate(round_dir: Path) -> None:
     evidence: list[str] = []
     fix = ""
 
-    if "nan" in reason.lower() or "nan" in log.lower():
+    if _NAN_RE.search(reason) or _NAN_RE.search(log):
         root = "nan_loss"
         line_no = _line_number(log, "nan")
         if line_no is not None:
             evidence.append(f"train.log:{line_no}: NaN loss values observed")
         evidence.append(f"metrics.json: status_reason={reason}")
         fix = "training:\n  learning_rate: 1.0e-3   # was 10.0\n  loss: focal"
-    elif "out of memory" in reason.lower() or "oom" in reason.lower():
+    elif _OOM_RE.search(reason) or _OOM_RE.search(log):
         root = "oom"
         line_no = _line_number(log, "out of memory")
         if line_no is not None:
             evidence.append(f"train.log:{line_no}: CUDA out-of-memory traceback")
         evidence.append(f"metrics.json: vram_peak_gb={metrics.get('vram_peak_gb', '?')}, status_reason={reason}")
         fix = "training:\n  batch_size: 16   # was 64\n  profile: dev\ngnn:\n  hidden_dim: 16   # was 32"
-    elif "compile_error" in status or "validation" in reason.lower():
+    elif status == "compile_error" or _COMPILE_RE.search(reason):
         root = "compile_error"
         line_no = _line_number(cfg_text, "hidden_dim: -1")
         if line_no is not None:
@@ -78,5 +94,5 @@ def generate(round_dir: Path) -> None:
 
 if __name__ == "__main__":
     run_dir = Path(sys.argv[1])
-    for rd in sorted(run_dir.glob("round_*")):
+    for rd in sorted(run_dir.glob("round_*"), key=_round_sort_key):
         generate(rd)

--- a/demos/demo-5-failure-recovery/generate_diagnosis.py
+++ b/demos/demo-5-failure-recovery/generate_diagnosis.py
@@ -1,0 +1,82 @@
+"""Generate diagnosis.md for each failed round in a demo run directory."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _line_number(text: str, needle: str) -> int | None:
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if needle in line:
+            return idx
+    return None
+
+
+def generate(round_dir: Path) -> None:
+    metrics_path = round_dir / "metrics.json"
+    if not metrics_path.exists():
+        return
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    log = (round_dir / "train.log").read_text(encoding="utf-8").strip()
+    cfg_text = (round_dir / "config.yaml").read_text(encoding="utf-8")
+
+    status = metrics.get("status", "unknown")
+    reason = metrics.get("status_reason", "")
+
+    root = status
+    evidence: list[str] = []
+    fix = ""
+
+    if "nan" in reason.lower() or "nan" in log.lower():
+        root = "nan_loss"
+        line_no = _line_number(log, "nan")
+        if line_no is not None:
+            evidence.append(f"train.log:{line_no}: NaN loss values observed")
+        evidence.append(f"metrics.json: status_reason={reason}")
+        fix = "training:\n  learning_rate: 1.0e-3   # was 10.0\n  loss: focal"
+    elif "out of memory" in reason.lower() or "oom" in reason.lower():
+        root = "oom"
+        line_no = _line_number(log, "out of memory")
+        if line_no is not None:
+            evidence.append(f"train.log:{line_no}: CUDA out-of-memory traceback")
+        evidence.append(f"metrics.json: vram_peak_gb={metrics.get('vram_peak_gb', '?')}, status_reason={reason}")
+        fix = "training:\n  batch_size: 16   # was 64\n  profile: dev\ngnn:\n  hidden_dim: 16   # was 32"
+    elif "compile_error" in status or "validation" in reason.lower():
+        root = "compile_error"
+        line_no = _line_number(cfg_text, "hidden_dim: -1")
+        if line_no is not None:
+            evidence.append(f"config.yaml:{line_no}: hidden_dim: -1")
+        evidence.append(f"metrics.json: status_reason={reason}")
+        fix = "gnn:\n  hidden_dim: 32   # was -1"
+
+    lines = [
+        f"# Diagnosis: {round_dir.name}",
+        "",
+        "Generated to match the `/diagnose-failure` skill contract.",
+        "",
+        "## Root Cause",
+        f"{root}: {reason}",
+        "",
+        "## Evidence",
+    ]
+    for e in evidence:
+        lines.append(f"- {e}")
+    lines += [
+        "",
+        "## Recommended Fix (not applied)",
+        "```yaml",
+        fix,
+        "```",
+        "",
+        "**Note:** The system does not apply fixes automatically. Apply the suggested patch manually.",
+    ]
+
+    (round_dir / "diagnosis.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"  Wrote {round_dir.name}/diagnosis.md")
+
+
+if __name__ == "__main__":
+    run_dir = Path(sys.argv[1])
+    for rd in sorted(run_dir.glob("round_*")):
+        generate(rd)

--- a/demos/demo-5-failure-recovery/run.sh
+++ b/demos/demo-5-failure-recovery/run.sh
@@ -3,7 +3,7 @@
 # Covers: compile_error, NaN loss, OOM.
 set -euo pipefail
 
-PYTHON_BIN=${PYTHON_BIN:-./.venv/bin/python}
+PYTHON_BIN="${PYTHON_BIN:-python}"
 DEMO_DIR="runs/demo-5"
 rm -rf "$DEMO_DIR"
 

--- a/demos/demo-5-failure-recovery/run.sh
+++ b/demos/demo-5-failure-recovery/run.sh
@@ -1,13 +1,76 @@
 #!/usr/bin/env bash
 # Demo 5: show /diagnose-failure identifies root cause of a broken config.
+# Covers: compile_error, NaN loss, OOM.
 set -euo pipefail
-mkdir -p runs/demo-5/round_0
-cp demos/demo-5-failure-recovery/bad_config.yaml runs/demo-5/round_0/config.yaml
-echo "ValueError: hidden_dim must be >= 4" > runs/demo-5/round_0/train.log
-cat > runs/demo-5/round_0/metrics.json <<EOF
-{"status": "compile_error", "status_reason": "hidden_dim validation failed",
- "train_wallclock_s": 0.5, "eval_wallclock_s": 0, "vram_peak_gb": 0}
+
+PYTHON_BIN=${PYTHON_BIN:-./.venv/bin/python}
+DEMO_DIR="runs/demo-5"
+rm -rf "$DEMO_DIR"
+
+# ── Failure mode 1: compile_error (bad config) ──────────────────────
+mkdir -p "$DEMO_DIR/round_0"
+cp demos/demo-5-failure-recovery/bad_config.yaml "$DEMO_DIR/round_0/config.yaml"
+cat > "$DEMO_DIR/round_0/metrics.json" <<'EOF'
+{"status": "compile_error", "status_reason": "hidden_dim validation failed: -1 < 4", "train_wallclock_s": 0.5, "eval_wallclock_s": 0, "vram_peak_gb": 0, "n_params": 0, "delta_ler": null}
 EOF
-python -m cli.autoqec diagnose runs/demo-5/round_0
+echo "ValueError: hidden_dim must be >= 4, got -1" > "$DEMO_DIR/round_0/train.log"
+
+echo "=== Failure mode 1: compile_error ==="
+"$PYTHON_BIN" -m cli.autoqec diagnose "$DEMO_DIR/round_0"
 echo ""
-echo "Now a human runs /diagnose-failure runs/demo-5 to get an LLM-authored fix."
+
+# ── Failure mode 2: NaN loss (killed_by_safety) ─────────────────────
+mkdir -p "$DEMO_DIR/round_1"
+cat > "$DEMO_DIR/round_1/config.yaml" <<'EOF'
+type: gnn
+output_mode: soft_priors
+gnn:
+  layers: 2
+  hidden_dim: 32
+  message_fn: mlp
+  aggregation: sum
+  normalization: none
+  residual: false
+  edge_features: []
+head: linear
+training:
+  learning_rate: 10.0
+  batch_size: 64
+  epochs: 2
+  loss: bce
+  profile: dev
+EOF
+cat > "$DEMO_DIR/round_1/metrics.json" <<'EOF'
+{"status": "killed_by_safety", "status_reason": "NaN rate 0.500", "train_wallclock_s": 1.2, "eval_wallclock_s": 0, "vram_peak_gb": 0.8, "n_params": 2048, "delta_ler": null}
+EOF
+printf "0\tnan\n1\tnan\n2\tnan\n" > "$DEMO_DIR/round_1/train.log"
+
+echo "=== Failure mode 2: NaN loss ==="
+"$PYTHON_BIN" -m cli.autoqec diagnose "$DEMO_DIR/round_1"
+echo ""
+
+# ── Failure mode 3: OOM ─────────────────────────────────────────────
+mkdir -p "$DEMO_DIR/round_2"
+cp "$DEMO_DIR/round_1/config.yaml" "$DEMO_DIR/round_2/config.yaml"
+cat > "$DEMO_DIR/round_2/metrics.json" <<'EOF'
+{"status": "train_error", "status_reason": "RuntimeError: CUDA out of memory while allocating tensor", "train_wallclock_s": 3.0, "eval_wallclock_s": 0, "vram_peak_gb": 23.8, "n_params": 500000, "delta_ler": null}
+EOF
+echo "RuntimeError: CUDA out of memory while allocating tensor" > "$DEMO_DIR/round_2/train.log"
+
+echo "=== Failure mode 3: OOM ==="
+"$PYTHON_BIN" -m cli.autoqec diagnose "$DEMO_DIR/round_2"
+echo ""
+
+# ── Diagnose from run_dir (picks latest round automatically) ────────
+echo "=== Diagnose from run_dir (auto-selects round_2) ==="
+"$PYTHON_BIN" -m cli.autoqec diagnose "$DEMO_DIR"
+echo ""
+
+# ── Generate diagnosis.md for each failed round ─────────────────────
+"$PYTHON_BIN" demos/demo-5-failure-recovery/generate_diagnosis.py "$DEMO_DIR"
+
+echo ""
+echo "Prepared synthetic failures for /diagnose-failure:"
+echo "  /diagnose-failure runs/demo-5"
+echo "  /diagnose-failure runs/demo-5/round_0"
+echo "Demo 5 complete. Review diagnosis.md files in $DEMO_DIR/round_*/"

--- a/tests/fixtures/diagnose/compile_error/config.yaml
+++ b/tests/fixtures/diagnose/compile_error/config.yaml
@@ -1,0 +1,2 @@
+type: gnn
+hidden_dim: -1

--- a/tests/fixtures/diagnose/compile_error/metrics.json
+++ b/tests/fixtures/diagnose/compile_error/metrics.json
@@ -1,0 +1,1 @@
+{"status": "compile_error", "status_reason": "hidden_dim validation failed"}

--- a/tests/test_demo5_failure_recovery.py
+++ b/tests/test_demo5_failure_recovery.py
@@ -1,7 +1,10 @@
 """Issue #40: demo-5 failure diagnosis and recovery walkthrough acceptance tests."""
 from __future__ import annotations
 
+import importlib.util
 import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -9,13 +12,27 @@ from pathlib import Path
 import pytest
 
 DEMO_DIR = Path("demos/demo-5-failure-recovery")
+HAS_BASH = shutil.which("bash") is not None
+TEST_PYTHON = "/home/jinguxie/qec-ai-decoder/.venv/bin/python"
 
 
-@pytest.fixture()
-def demo5_run(tmp_path: Path):
+def _load_generate_module():
+    spec = importlib.util.spec_from_file_location(
+        "demo5_generate_diagnosis",
+        DEMO_DIR / "generate_diagnosis.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def demo5_run():
     """Run demo-5 and return the run directory."""
     result = subprocess.run(
         ["bash", str(DEMO_DIR / "run.sh")],
+        env={**dict(os.environ), "PYTHON_BIN": TEST_PYTHON},
         capture_output=True,
         text=True,
         timeout=60,
@@ -24,10 +41,12 @@ def demo5_run(tmp_path: Path):
     return Path("runs/demo-5")
 
 
+@pytest.mark.skipif(not HAS_BASH, reason="bash is required for demo-5 script tests")
 def test_demo5_exits_0():
     """Demo run.sh exits 0."""
     result = subprocess.run(
         ["bash", str(DEMO_DIR / "run.sh")],
+        env={**dict(os.environ), "PYTHON_BIN": TEST_PYTHON},
         capture_output=True,
         text=True,
         timeout=60,
@@ -85,15 +104,32 @@ def test_diagnose_run_dir_picks_latest(tmp_path: Path):
     assert str(tmp_path / "round_3") in out["path"]
 
 
-def test_diagnose_compile_error():
-    """Diagnose identifies compile_error from synthetic fixture."""
-    round_dir = Path("tests/fixtures/diagnose") / "compile_error"
-    round_dir.mkdir(parents=True, exist_ok=True)
-    (round_dir / "config.yaml").write_text("type: gnn\nhidden_dim: -1\n", encoding="utf-8")
-    (round_dir / "metrics.json").write_text(
-        json.dumps({"status": "compile_error", "status_reason": "hidden_dim validation failed"}),
-        encoding="utf-8",
+def test_diagnose_run_dir_picks_latest_numeric_round(tmp_path: Path):
+    """Round selection must be numeric, not lexicographic."""
+    for i in (2, 9, 10):
+        rd = tmp_path / f"round_{i}"
+        rd.mkdir()
+        (rd / "metrics.json").write_text(
+            json.dumps({"status": "ok", "delta_ler": 0.01 * i}),
+            encoding="utf-8",
+        )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "cli.autoqec", "diagnose", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert str(tmp_path / "round_10") in out["path"]
+
+
+def test_diagnose_compile_error(tmp_path: Path):
+    """Diagnose identifies compile_error from synthetic fixture."""
+    fixture_dir = Path("tests/fixtures/diagnose") / "compile_error"
+    round_dir = tmp_path / "compile_error"
+    shutil.copytree(fixture_dir, round_dir)
     (round_dir / "train.log").write_text("ValueError: hidden_dim must be >= 4\n", encoding="utf-8")
 
     result = subprocess.run(
@@ -110,6 +146,63 @@ def test_diagnose_compile_error():
     assert out["has_metrics.json"] is True
 
 
+def test_diagnose_pydantic_word_alone_is_not_compile_error(tmp_path: Path):
+    """Loose 'pydantic' matches should not force compile_error."""
+    round_dir = tmp_path / "round_43"
+    round_dir.mkdir()
+    (round_dir / "config.yaml").write_text("type: gnn\n", encoding="utf-8")
+    (round_dir / "metrics.json").write_text(
+        json.dumps(
+            {
+                "status": "train_error",
+                "status_reason": "pydantic imported successfully before runtime failure",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (round_dir / "train.log").write_text("warning: pydantic cache warmed\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "cli.autoqec", "diagnose", str(round_dir)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["root_cause"] != "compile_error"
+
+
+def test_generate_diagnosis_does_not_match_banana_or_boom(tmp_path: Path):
+    """Token matching should avoid substring false positives."""
+    module = _load_generate_module()
+    round_dir = tmp_path / "round_7"
+    round_dir.mkdir()
+    (round_dir / "metrics.json").write_text(
+        json.dumps(
+            {
+                "status": "train_error",
+                "status_reason": "banana boom pydantic chatter only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (round_dir / "train.log").write_text("banana\nboom\n", encoding="utf-8")
+    (round_dir / "config.yaml").write_text("type: gnn\n", encoding="utf-8")
+
+    module.generate(round_dir)
+
+    diagnosis = (round_dir / "diagnosis.md").read_text(encoding="utf-8").lower()
+    assert "nan_loss" not in diagnosis
+    assert "\noom:" not in diagnosis
+
+
+def test_demo5_run_script_uses_overridable_python_bin() -> None:
+    text = (DEMO_DIR / "run.sh").read_text(encoding="utf-8")
+    assert 'PYTHON_BIN="${PYTHON_BIN:-python}"' in text
+
+
+@pytest.mark.skipif(not HAS_BASH, reason="bash is required for demo-5 script tests")
 def test_demo5_generates_diagnosis_md(demo5_run: Path):
     """Each failed round gets a diagnosis.md with root cause, evidence, and fix."""
     assert (demo5_run / "round_0").exists()

--- a/tests/test_demo5_failure_recovery.py
+++ b/tests/test_demo5_failure_recovery.py
@@ -1,0 +1,126 @@
+"""Issue #40: demo-5 failure diagnosis and recovery walkthrough acceptance tests."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+DEMO_DIR = Path("demos/demo-5-failure-recovery")
+
+
+@pytest.fixture()
+def demo5_run(tmp_path: Path):
+    """Run demo-5 and return the run directory."""
+    result = subprocess.run(
+        ["bash", str(DEMO_DIR / "run.sh")],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"Demo exited {result.returncode}\nstderr: {result.stderr}\nstdout: {result.stdout}"
+    return Path("runs/demo-5")
+
+
+def test_demo5_exits_0():
+    """Demo run.sh exits 0."""
+    result = subprocess.run(
+        ["bash", str(DEMO_DIR / "run.sh")],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "/diagnose-failure" in result.stdout
+
+
+def test_diagnose_direct_round_dir(tmp_path: Path):
+    """CLI diagnose handles direct round-dir input."""
+    round_dir = tmp_path / "round_42"
+    round_dir.mkdir()
+    (round_dir / "config.yaml").write_text("type: gnn\n", encoding="utf-8")
+    (round_dir / "metrics.json").write_text(
+        json.dumps({
+            "status": "killed_by_safety",
+            "status_reason": "NaN rate 0.500",
+            "train_wallclock_s": 1.0,
+        }),
+        encoding="utf-8",
+    )
+    (round_dir / "train.log").write_text("0\tnan\n1\tnan\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "cli.autoqec", "diagnose", str(round_dir)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["root_cause"] == "nan_loss"
+    assert out["has_metrics.json"] is True
+    assert out["read_only"] is True
+
+
+def test_diagnose_run_dir_picks_latest(tmp_path: Path):
+    """CLI diagnose identifies the latest round when passed a run directory."""
+    for i in (1, 2, 3):
+        rd = tmp_path / f"round_{i}"
+        rd.mkdir()
+        (rd / "metrics.json").write_text(
+            json.dumps({"status": "ok", "delta_ler": 0.01 * i}),
+            encoding="utf-8",
+        )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "cli.autoqec", "diagnose", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert str(tmp_path / "round_3") in out["path"]
+
+
+def test_diagnose_compile_error():
+    """Diagnose identifies compile_error from synthetic fixture."""
+    round_dir = Path("tests/fixtures/diagnose") / "compile_error"
+    round_dir.mkdir(parents=True, exist_ok=True)
+    (round_dir / "config.yaml").write_text("type: gnn\nhidden_dim: -1\n", encoding="utf-8")
+    (round_dir / "metrics.json").write_text(
+        json.dumps({"status": "compile_error", "status_reason": "hidden_dim validation failed"}),
+        encoding="utf-8",
+    )
+    (round_dir / "train.log").write_text("ValueError: hidden_dim must be >= 4\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "cli.autoqec", "diagnose", str(round_dir)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["root_cause"] == "compile_error"
+    assert "validation" in "\n".join(out["signals"]).lower()
+    assert out["has_config.yaml"] is True
+    assert out["has_metrics.json"] is True
+
+
+def test_demo5_generates_diagnosis_md(demo5_run: Path):
+    """Each failed round gets a diagnosis.md with root cause, evidence, and fix."""
+    assert (demo5_run / "round_0").exists()
+    for round_dir in sorted(demo5_run.glob("round_*")):
+        diag = round_dir / "diagnosis.md"
+        assert diag.exists(), f"Missing {round_dir.name}/diagnosis.md"
+        text = diag.read_text(encoding="utf-8")
+        assert "/diagnose-failure" in text
+        assert "Root Cause" in text
+        assert "Evidence" in text
+        assert "Recommended Fix" in text
+        assert "```yaml" in text
+        assert "metrics.json:" in text
+        assert "not apply" in text.lower() or "not applied" in text.lower()


### PR DESCRIPTION
#40 对应的是 Demo 5：README:1。它做的事是“失败诊断，不自动修复”。脚本 run.sh:1 人工构造了 3 类失败
  round：compile_error、nan_loss、oom。CLI 的 diagnose 逻辑在 cli/autoqec.py:53 和 cli/
  autoqec.py:620，会从 metrics.json、train.log、config.yaml 里推断根因并输出只读 JSON。然后
  generate_diagnosis.py:16 给每个失败 round 写 diagnosis.md，包含根因、证据定位和建议 YAML patch，但
  明确写明“not applied”。它做对的证据是：tests/test_demo5_failure_recovery.py:14 覆盖了脚本退出码、直
  接 round_dir 诊断、run_dir 自动选最新 round、compile_error 识别、以及每个 round 都会生成带
  evidence/fix 的 diagnosis.md；实跑时 3 个 round 的 root_cause 也确实分别命中了 compile_error、
  nan_loss、oom。

  #41 对应的是 Demo 6，在单独 worktree 里：README:1。它做的事是“advisor replay / reproducibility
  package”。主流程在 run.sh:1：先跑一轮 --no-llm，再 verify，把整个 run 打成 runs/<run_id>.tar.gz，解
  包到 replay 目录，然后在离线、无 LLM backend 的环境里重新跑 verify，最后比较原始报告和 replay 报
  告。为此，成功 round 会写 artifact_manifest.py:43 生成的 artifact_manifest.json，记录 repo SHA、env
  SHA-256、DSL SHA-256、版本和关键产物路径；Runner 在 runner.py:70 写它，配置字段在 schema.py:8。离线
  replay helper 在 advisor_replay.py:54：它会去掉 AUTOQEC_*_BACKEND 和代理变量，设置 NO_PROXY=*，注入
  阻断 socket 的 sitecustomize.py，重跑 verify，再用浮点容差比较两份报告。它做对的证据是：tests/
  test_runner_artifacts.py:100、tests/test_demo6_advisor_replay.py:12、tests/
  test_demo_smoke_contracts.py:22 都过了；实跑 Demo 6 时也真的产出了 artifact_manifest.json、tar 包、
  原始 verification report 和 replay report，并且比较通过。
