### PR TITLE
feat(bundle): /demo-presenter skill, Demo 4 narration, branding, status, codecov, and README refresh

### DIFF
--- a/.claude/skills/demo-presenter/SKILL.md
+++ b/.claude/skills/demo-presenter/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: demo-presenter
+description: Use when preparing an AutoQEC demo walkthrough, advisor presentation, hackathon pitch, recorded narration, or evidence-backed explanation of why the demos matter and why their outputs are correct.
+---
+
+# Demo Presenter
+
+## Overview
+
+Create a persuasive, human-voiced AutoQEC demonstration from repository
+evidence. The output must distinguish what is merged on `main`, what is
+planned or present only on a PR branch, and what was actually verified during
+the current session.
+
+## Core Rule
+
+Never invent demo results. Use only repository files, command output, committed
+snapshots, or explicitly-labeled planned/PR evidence. If a command is not run,
+say it is a scriptable talking point, not a fresh verification.
+
+## Evidence First
+
+Before writing the presentation, collect the current evidence:
+
+1. Read `README.md`, especially the one-prompt review block, feature table,
+   demo table, and skill table.
+2. Read demo docs:
+   - `demos/demo-1-surface-d5/README.md`
+   - `demos/demo-2-bb72/README.md`
+   - `demos/demo-4-reward-hacking/README.md`
+   - `demos/demo-4-reward-hacking/walkthrough.md` when explaining integrity.
+   - `demos/demo-5-failure-recovery/README.md`
+3. Check current branch state with `git status --short --branch`.
+4. If asked for a live presentation, run the README's demo commands in order
+   and capture command, wall-clock, pass/fail, artifact paths, and the last
+   error lines for failures.
+5. If asked for a scripted or dry-run presentation, use committed snapshots and
+   label them as snapshots.
+6. For the planned worktree demo, inspect `origin/feat/issue-38-worktree-demo`
+   without switching away from `main`:
+
+```bash
+git show origin/feat/issue-38-worktree-demo:demos/demo-3-worktree-provenance/README.md
+git show origin/feat/issue-38-worktree-demo:demos/demo-3-worktree-provenance/expected_output/run_demo.stdout.txt
+git diff --name-status main..origin/feat/issue-38-worktree-demo
+```
+
+Treat this as planned / PR-only until the files exist on `main`.
+
+## Spoken Audio
+
+If the user wants AI narration, write the `Narration Script` section to a plain
+text file and run the bundled TTS helper:
+
+```bash
+python .claude/skills/demo-presenter/scripts/speak_demo.py demo_script.txt --output runs/demo_audio.mp3
+```
+
+Requirements:
+
+- Set `OPENAI_API_KEY` in the shell.
+- If using an OpenAI-compatible gateway, set `OPENAI_BASE_URL` or pass
+  `--base-url`.
+- Install the optional `openai` Python package if the script reports that it is
+  missing.
+- Tell listeners the voice is AI-generated.
+
+Useful options:
+
+```bash
+python .claude/skills/demo-presenter/scripts/speak_demo.py demo_script.txt \
+  --output runs/demo_audio.mp3 \
+  --voice coral \
+  --model gpt-4o-mini-tts \
+  --instructions "Speak like a warm, precise research demo host."
+```
+
+OpenAI-compatible gateway example:
+
+```bash
+export OPENAI_API_KEY="..."
+export OPENAI_BASE_URL="https://api.example.com"
+python .claude/skills/demo-presenter/scripts/speak_demo.py demo_script.txt --output runs/demo_audio.mp3
+```
+
+For long scripts, the helper splits requests. If `ffmpeg` is installed it also
+combines the parts into the requested output file; otherwise it leaves numbered
+part files plus a playlist next to the requested output.
+
+## Live Narrated Demo
+
+If the user asks to run demos while AI narrates, use the live runner:
+
+```bash
+python .claude/skills/demo-presenter/scripts/live_present_demo.py --output-dir runs/demo-presenter-live/manual
+```
+
+Behavior:
+
+- Plays or writes an opening narration.
+- For each demo, starts the "why it matters" narration and the demo command
+  **concurrently** so the listener hears the context while the command actually
+  runs. The runner waits for both before moving on.
+- Narrates the pass/fail meaning after the command exits (sequential, so the
+  listener hears the verdict before the next demo starts).
+- Writes per-demo logs and `manifest.json` under the output directory.
+- Keeps Demo 3 worktree provenance as planned / PR-only unless
+  `--include-pr-worktree` is passed and the demo directory exists locally.
+
+### Audio player requirements for parallel playback
+
+The overlap uses a non-blocking CLI player. The runner auto-detects, in order:
+`ffplay`, `afplay` (macOS), `mpv`, `mpg123`, `paplay`, `aplay`. Install one so
+the narration does not open a GUI media player:
+
+- **Windows / cross-platform**: install `ffmpeg` (which ships `ffplay`).
+- **macOS**: `afplay` is preinstalled.
+- **Linux**: `mpv` or PulseAudio's `paplay` are common choices.
+
+If no async player is found, pre-narration falls back to blocking playback (the
+platform default, which may open a GUI). Use `--no-overlap` to force this
+sequential mode even when an async player is available.
+
+Useful options:
+
+```bash
+python .claude/skills/demo-presenter/scripts/live_present_demo.py \
+  --output-dir runs/demo-presenter-live/advisor \
+  --skip-demo 4 \
+  --include-pr-worktree
+```
+
+For rehearsal without running long commands or calling TTS:
+
+```bash
+python .claude/skills/demo-presenter/scripts/live_present_demo.py \
+  --dry-run \
+  --no-audio \
+  --output-dir runs/demo-presenter-live/rehearsal
+```
+
+For generating audio files without attempting playback:
+
+```bash
+python .claude/skills/demo-presenter/scripts/live_present_demo.py \
+  --no-playback \
+  --output-dir runs/demo-presenter-live/audio-only
+```
+
+To disable the concurrent playback and keep the old narrate-then-run ordering:
+
+```bash
+python .claude/skills/demo-presenter/scripts/live_present_demo.py \
+  --no-overlap \
+  --output-dir runs/demo-presenter-live/sequential
+```
+
+## Demo Order
+
+Use this sequence unless the user asks otherwise:
+
+| Segment | Status label | Command or source | Claim to prove |
+|---|---|---|---|
+| Opening | Context | `README.md` | AutoQEC is an agentic research harness for neural predecoders, not just a training script. |
+| Demo 1: surface_d5 | Merged on main | `bash demos/demo-1-surface-d5/run_quick.sh` | The full DSL -> train -> eval -> artifact loop works on the surface-code/MWPM path. |
+| Demo 2: BB72 qLDPC | Merged on main | `MODE=fast bash demos/demo-2-bb72/run.sh` | The same harness swaps to qLDPC/OSD through environment config rather than special-case code. |
+| Demo 3: worktree provenance | Planned / PR-only until merged | `origin/feat/issue-38-worktree-demo:demos/demo-3-worktree-provenance/README.md` | Branches-as-Pareto preserves provenance, supports compose rounds, and records merge conflicts as scientific outcomes. |
+| Demo 4: reward-hacking rejection | Merged on main | `bash demos/demo-4-reward-hacking/present.sh` | A memorizing cheater is rejected by independent verification, so the Pareto front is guarded. |
+| Demo 5: failure recovery | Merged on main | `bash demos/demo-5-failure-recovery/run.sh` | Broken rounds produce machine-readable root cause signals for diagnosis. |
+| Closing | Synthesis | Artifacts and pass/fail table | Importance: reproducible automated discovery. Correctness: artifacts, holdout verification, backend switching, provenance, and diagnostics. |
+
+## Presentation Shape
+
+Return a presentation with these sections:
+
+1. **Run Card**: repo branch, commit SHA if available, whether commands were
+   executed live or summarized from snapshots, and any PR-only evidence used.
+2. **Narration Script**: first-person host voice, concise and human. Speak as
+   an expert guide: "Now I want to show why this matters..." Avoid hype that
+   outruns the evidence.
+3. **Demo Beats**: for each demo, include:
+   - what the audience sees,
+   - command or source file,
+   - pass/fail criterion,
+   - artifact path,
+   - why it matters,
+   - why it supports correctness.
+4. **Evidence Table**: demo, status label, command/source, key artifact,
+   pass/fail or snapshot-only, claim proven.
+5. **Honest Limits**: noisy dev-profile LER, unverified candidate Pareto,
+   PR-only worktree demo status, skipped live-LLM path, or failed commands.
+6. **Closing Argument**: one paragraph connecting the demos to the core claim:
+   AutoQEC is a reproducible, auditable harness for agent-driven QEC decoder
+   research.
+
+## Voice Rules
+
+- Use a warm, technically credible presenter voice.
+- Explain importance before correctness for each demo.
+- Prefer concrete language over slogans: "this writes `metrics.json` and
+  `checkpoint.pt`" beats "this proves everything works."
+- Say "planned / PR-only" for Demo 3 until it is merged.
+- Do not claim a PR-only demo passed on `main`.
+- Do not claim VERIFIED status for no-LLM candidate Pareto output unless an
+  independent verifier report says so.
+
+## Explanation-mode demos (visualized walkthroughs)
+
+Some demos ship two launchers:
+
+- `run.sh` — CI-style pass/fail, one-shot exit code.
+- `present.sh` — narrated, multi-phase output with ASCII visualizations
+  and an optional PNG. Same exit semantics as `run.sh`, but stdout is
+  structured so a presenter can comment on each phase as it lands.
+
+Prefer `present.sh` whenever a human is watching. `run.sh` stays the
+stable CI entry point; do not remove it.
+
+### Demo 4 — how to narrate the five phases
+
+`bash demos/demo-4-reward-hacking/present.sh` prints five phase headers
+(`PHASE 1 … PHASE 5`) in order and writes `present_summary.json` plus
+`visualizations/scoreboard.png` under `runs/demo-4/round_0/`. When
+narrating, do exactly one thing per phase — do not front-load conclusions:
+
+1. **PHASE 1 — Construct the cheater.** Point out the memorized-entry
+   count and the training seed range. Say out loud: "this is an
+   adversarial example, not a bug — I am building the worst-case reviewer
+   submission to check the verifier actually catches it."
+2. **PHASE 2 — Hit-rate scoreboard.** Three bars appear (memorized /
+   fresh-train / holdout). The scientific punchline is that the cheat is
+   bound to *specific shots*, not to seed ranges: fresh train-seed hits
+   ≈ holdout hits. Narrate this explicitly — it is the key to why the
+   `seed-leakage` guard *passes* while the cheat still fails the fair test.
+3. **PHASE 3 — Fair-test LER.** Two bars appear (plain MWPM vs
+   memorizer). Read out Δ_LER (holdout) and the 95% CI. Emphasise that
+   the memorizer is not merely weaker — it is *worse than doing nothing*
+   because missed lookups poison the MWPM backend with a zero hint.
+4. **PHASE 4 — Three guards checklist.** For each guard, state which
+   failure mode it covers. Call out which guard tripped (usually
+   `paired bootstrap CI` for this cheat). Mention that a different
+   cheater class (e.g. `trap_A` seed leakage, `trap_C` ablation fail)
+   would trip a different guard — the guards are not redundant.
+5. **PHASE 5 — Verdict + Pareto consequence.** Read the banner verdict
+   (expected: `FAILED`; `SUSPICIOUS` is also acceptable rejection).
+   State the Pareto consequence explicitly: the checkpoint is not
+   admitted to `pareto.json`; the run's branch would be tagged
+   `rejected_by_verifier` in `fork_graph.json`.
+
+Artifacts to cite by path after the walkthrough:
+
+- `runs/demo-4/round_0/verification_report.json` — the machine-readable verdict
+- `runs/demo-4/round_0/present_summary.json` — the phase-by-phase log
+- `runs/demo-4/round_0/visualizations/scoreboard.png` — 2-panel figure
+
+If matplotlib is unavailable, present.py prints
+`(matplotlib unavailable, skipping PNG)` and exits 0; the ASCII output
+alone is sufficient — do not treat the missing PNG as a failure.
+
+## Worktree Demo Handling
+
+When including the worktree demo before merge:
+
+1. Identify it as `Demo 3 - Worktree branches-as-Pareto provenance`.
+2. State that it currently lives on `origin/feat/issue-38-worktree-demo`, not
+   on `main`, unless the demo directory is present locally.
+3. Summarize the expected sequence:
+   - Round 1 forks Idea A from baseline.
+   - Round 2 forks Idea B from baseline.
+   - Round 3 composes A and B with a merge worktree.
+   - A conflict probe records `status="compose_conflict"` instead of crashing.
+   - `reconcile_at_startup` can recover orphaned branch rows from pointer JSON.
+4. Cite PR-branch evidence such as:
+   - `demos/demo-3-worktree-provenance/README.md`
+   - `expected_output/run_demo.stdout.txt`
+   - `round_1_pointer.json`
+5. Explain why it matters: research candidates become inspectable git branches,
+   not opaque rows in a database.
+6. Explain correctness: branch names, commit SHAs, pointer JSON, merge graph,
+   and conflict status make provenance auditable.
+
+## Failure Handling
+
+If a demo command fails, keep going. In the presentation:
+
+- mark that demo as failed,
+- include the last useful stdout/stderr lines,
+- explain which claim is not freshly supported,
+- distinguish "the command failed in this environment" from "the design claim is false",
+- do not hide failures behind narration.
+
+## Quick Prompt Pattern
+
+User: "Use `/demo-presenter` to prepare the advisor walkthrough."
+
+You:
+
+1. Collect evidence.
+2. Ask whether to run live commands if the user did not specify live vs dry-run.
+3. Produce the run card, narration script, demo beats, evidence table, limits,
+   and closing argument.

--- a/.claude/skills/demo-presenter/agents/openai.yaml
+++ b/.claude/skills/demo-presenter/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Demo Presenter"
+  short_description: "Generate an evidence-backed AutoQEC demo presentation."
+  default_prompt: "Use $demo-presenter to prepare a persuasive, human-voiced AutoQEC demo walkthrough from repository evidence."

--- a/.claude/skills/demo-presenter/scripts/live_present_demo.py
+++ b/.claude/skills/demo-presenter/scripts/live_present_demo.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import platform
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPEAK_DEMO_PATH = Path(__file__).with_name("speak_demo.py")
+DEFAULT_RUN_ROOT = Path("runs/demo-presenter-live")
+DEFAULT_MODEL = "gpt-4o-mini-tts"
+DEFAULT_VOICE = "coral"
+DEFAULT_INSTRUCTIONS = (
+    "Speak like a warm, precise research demo host. Keep each segment concise."
+)
+# Non-blocking audio players, in preference order. afplay is macOS-only.
+ASYNC_PLAYERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("ffplay", ("-nodisp", "-autoexit", "-loglevel", "quiet")),
+    ("afplay", ()),
+    ("mpv", ("--no-video", "--really-quiet")),
+    ("mpg123", ("-q",)),
+    ("paplay", ()),
+    ("aplay", ("-q",)),
+)
+
+
+@dataclass(frozen=True)
+class DemoStep:
+    demo_id: str
+    name: str
+    status: str
+    command: list[str] | None
+    pre_narration: str
+    post_success: str
+    post_failure: str
+    artifacts: list[str]
+
+
+def load_speak_demo():
+    spec = importlib.util.spec_from_file_location("speak_demo", SPEAK_DEMO_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SPEAK_DEMO_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_demo_steps(include_pr_worktree: bool = False) -> list[DemoStep]:
+    worktree_command = None
+    if include_pr_worktree and (REPO_ROOT / "demos/demo-3-worktree-provenance/run.sh").exists():
+        worktree_command = ["bash", "demos/demo-3-worktree-provenance/run.sh"]
+
+    return [
+        DemoStep(
+            demo_id="1",
+            name="surface_d5 end-to-end loop",
+            status="merged on main",
+            command=["bash", "demos/demo-1-surface-d5/run_quick.sh"],
+            pre_narration=(
+                "Demo 1 starts with the surface-code path. The important point is that "
+                "AutoQEC is not just printing a config; it will compile a decoder DSL, "
+                "train it, evaluate it, and write auditable artifacts."
+            ),
+            post_success=(
+                "Demo 1 finished. The correctness evidence is structural: the run wrote "
+                "history, Pareto candidate data, a trained checkpoint, logs, and metrics "
+                "for the surface-code backend."
+            ),
+            post_failure=(
+                "Demo 1 did not complete in this environment. Keep the failure visible; "
+                "the surface-code end-to-end claim is not freshly supported by this run."
+            ),
+            artifacts=[
+                "runs/<latest>/history.jsonl",
+                "runs/<latest>/candidate_pareto.json",
+                "runs/<latest>/round_1/metrics.json",
+            ],
+        ),
+        DemoStep(
+            demo_id="2",
+            name="BB72 qLDPC backend switch",
+            status="merged on main",
+            command=["bash", "demos/demo-2-bb72/run.sh"],
+            pre_narration=(
+                "Demo 2 switches code families. We keep the same harness but move from "
+                "surface-code MWPM to BB72 qLDPC with OSD through environment config."
+            ),
+            post_success=(
+                "Demo 2 finished. The key evidence is that the qLDPC run produces the "
+                "same artifact shape while using the OSD classical backend."
+            ),
+            post_failure=(
+                "Demo 2 failed here. The generic-backend claim needs triage before using "
+                "this as fresh live evidence."
+            ),
+            artifacts=["runs/<latest>/round_1/metrics.json", "autoqec/envs/builtin/bb72_depol.yaml"],
+        ),
+        DemoStep(
+            demo_id="3",
+            name="worktree branches-as-Pareto provenance",
+            status="planned / PR-only until merged",
+            command=worktree_command,
+            pre_narration=(
+                "Demo 3 is the provenance story. It is currently PR-only unless the demo "
+                "directory exists on main. The claim is that research candidates become "
+                "git branches with pointer JSON, compose merges, and recorded conflicts."
+            ),
+            post_success=(
+                "The worktree provenance demo finished. Branch names, commit SHAs, "
+                "pointer JSON, and merge graph output make candidate history auditable."
+            ),
+            post_failure=(
+                "The worktree demo was not run successfully from main. Present it as "
+                "planned or PR-only evidence, not as a merged live demo."
+            ),
+            artifacts=[
+                "origin/feat/issue-38-worktree-demo:demos/demo-3-worktree-provenance/README.md",
+                "origin/feat/issue-38-worktree-demo:demos/demo-3-worktree-provenance/expected_output/run_demo.stdout.txt",
+            ],
+        ),
+        DemoStep(
+            demo_id="4",
+            name="reward-hacking rejection (narrated)",
+            status="merged on main",
+            command=["bash", "demos/demo-4-reward-hacking/present.sh"],
+            pre_narration=(
+                "Demo 4 is the trust test, and you will see it unfold in five labeled "
+                "phases. Phase 1 builds a memorizing cheater from training-seed "
+                "syndromes. Phase 2 shows the table hit rate on memorized shots, fresh "
+                "train shots, and holdout shots; that comparison reveals the cheat is "
+                "bound to specific shots, not to seed ranges. Phase 3 runs the "
+                "independent verifier on holdout. Phase 4 checks the three guards -- "
+                "seed leakage, paired bootstrap CI, ablation sanity. Phase 5 reads the "
+                "verdict and states the Pareto consequence."
+            ),
+            post_success=(
+                "Demo 4 finished. The memorizer was rejected, the scoreboard PNG was "
+                "written under visualizations, and present_summary.json records the "
+                "phase-by-phase numbers. A memorizer should be SUSPICIOUS or FAILED, "
+                "never VERIFIED."
+            ),
+            post_failure=(
+                "Demo 4 failed here. Do not claim the verifier rejected the cheater in "
+                "this live session until the report exists and says so."
+            ),
+            artifacts=[
+                "runs/demo-4/round_0/verification_report.json",
+                "runs/demo-4/round_0/present_summary.json",
+                "runs/demo-4/round_0/visualizations/scoreboard.png",
+            ],
+        ),
+        DemoStep(
+            demo_id="5",
+            name="failure root-cause diagnosis",
+            status="merged on main",
+            command=["bash", "demos/demo-5-failure-recovery/run.sh"],
+            pre_narration=(
+                "Demo 5 shows operational recovery. A research harness needs useful "
+                "failure states, not just green-path metrics."
+            ),
+            post_success=(
+                "Demo 5 finished. The machine-readable compile_error and reason field "
+                "are what make diagnosis automatable."
+            ),
+            post_failure=(
+                "Demo 5 failed here, so the diagnostic claim is not freshly demonstrated "
+                "by this run."
+            ),
+            artifacts=["runs/demo-5/", "stdout JSON status_reason"],
+        ),
+    ]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run AutoQEC demos while generating and optionally playing narration."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Do not run demo commands.")
+    parser.add_argument("--no-audio", action="store_true", help="Write narration text only.")
+    parser.add_argument("--no-playback", action="store_true", help="Generate audio but do not play it.")
+    parser.add_argument(
+        "--no-overlap",
+        action="store_true",
+        help="Play pre-narration to completion before starting each demo command.",
+    )
+    parser.add_argument(
+        "--include-pr-worktree",
+        action="store_true",
+        help="Run Demo 3 only if its PR-only directory exists locally.",
+    )
+    parser.add_argument(
+        "--skip-demo",
+        action="append",
+        default=[],
+        help="Demo id to skip. Can be repeated, for example --skip-demo 4.",
+    )
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--voice", default=DEFAULT_VOICE)
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--instructions", default=DEFAULT_INSTRUCTIONS)
+    return parser
+
+
+def timestamped_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return DEFAULT_RUN_ROOT / stamp
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+def run_command(command: list[str], log_path: Path) -> subprocess.CompletedProcess[str]:
+    with log_path.open("w", encoding="utf-8") as log:
+        proc = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        log.write(proc.stdout)
+    return proc
+
+
+def _resolve_async_player(path: Path) -> list[str] | None:
+    system = platform.system()
+    for name, args in ASYNC_PLAYERS:
+        if name == "afplay" and system != "Darwin":
+            continue
+        exe = shutil.which(name)
+        if exe:
+            return [exe, *args, str(path)]
+    return None
+
+
+def start_playback(path: Path) -> subprocess.Popen | None:
+    """Start non-blocking audio playback. Returns Popen or None when no suitable
+    async player is available. Callers must wait() to avoid leaving the child
+    running past the step."""
+    if not path.exists() or path.suffix.lower() == ".txt":
+        return None
+    cmd = _resolve_async_player(path)
+    if cmd is None:
+        return None
+    try:
+        return subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return None
+
+
+def play_audio(path: Path) -> None:
+    """Blocking audio playback. Prefers the non-blocking player family so there
+    is no GUI popup; falls back to the platform default if none is installed."""
+    popen = start_playback(path)
+    if popen is not None:
+        popen.wait()
+        return
+    system = platform.system()
+    if system == "Windows":
+        subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                f"Start-Process -FilePath '{path}' -Wait",
+            ],
+            check=False,
+        )
+        return
+    if system == "Darwin":
+        subprocess.run(["afplay", str(path)], check=False)
+        return
+    subprocess.run(["xdg-open", str(path)], check=False)
+
+
+def synthesize_narration(
+    *,
+    text: str,
+    output_path: Path,
+    audio: bool,
+    base_url: str | None,
+    model: str,
+    voice: str,
+    instructions: str,
+) -> Path:
+    text_path = output_path.with_suffix(".txt")
+    write_text(text_path, text)
+    if not audio:
+        return text_path
+
+    speak_demo = load_speak_demo()
+    args = speak_demo.build_parser().parse_args(
+        [
+            str(text_path),
+            "--output",
+            str(output_path),
+            "--model",
+            model,
+            "--voice",
+            voice,
+            "--instructions",
+            instructions,
+            *(["--base-url", base_url] if base_url else []),
+        ]
+    )
+    speak_demo.synthesize_script(args)
+    return output_path
+
+
+def narrate(
+    *,
+    text: str,
+    output_path: Path,
+    audio: bool,
+    playback: bool,
+    base_url: str | None,
+    model: str,
+    voice: str,
+    instructions: str,
+) -> Path:
+    path = synthesize_narration(
+        text=text,
+        output_path=output_path,
+        audio=audio,
+        base_url=base_url,
+        model=model,
+        voice=voice,
+        instructions=instructions,
+    )
+    if audio and playback:
+        play_audio(path)
+    return path
+
+
+def _run_step_with_overlap(
+    *,
+    step: DemoStep,
+    pre_audio_path: Path,
+    log_path: Path,
+    dry_run: bool,
+    audio: bool,
+    playback: bool,
+    overlap: bool,
+) -> tuple[str, int | None]:
+    """Start the pre-narration playback and the demo command concurrently, then
+    wait for both. If no async player is available, fall back to sequential
+    pre-narration so the listener still hears the context."""
+    want_audio = audio and playback and pre_audio_path.suffix.lower() != ".txt"
+    audio_proc: subprocess.Popen | None = None
+
+    if want_audio:
+        if overlap:
+            audio_proc = start_playback(pre_audio_path)
+            if audio_proc is None:
+                # No async player — preserve narration by playing blocking.
+                play_audio(pre_audio_path)
+        else:
+            play_audio(pre_audio_path)
+
+    try:
+        if dry_run:
+            write_text(log_path, "dry-run: command not executed")
+            return "dry-run", None
+        if step.command is None:
+            write_text(log_path, "skipped: demo is not runnable from this checkout")
+            return "skipped", None
+        proc = run_command(step.command, log_path)
+        result = "passed" if proc.returncode == 0 else "failed"
+        return result, proc.returncode
+    finally:
+        if audio_proc is not None:
+            audio_proc.wait()
+
+
+def execute_demo_steps(
+    *,
+    steps: list[DemoStep],
+    output_dir: Path,
+    dry_run: bool,
+    audio: bool,
+    playback: bool,
+    base_url: str | None,
+    model: str,
+    voice: str,
+    instructions: str,
+    overlap: bool = True,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report: dict[str, Any] = {
+        "started_at": datetime.now().isoformat(timespec="seconds"),
+        "output_dir": str(output_dir),
+        "dry_run": dry_run,
+        "audio": audio,
+        "playback": playback,
+        "overlap": overlap,
+        "steps": [],
+    }
+
+    opening = (
+        "This is an AI-generated narration. I will run the AutoQEC demos in order, "
+        "explain why each one matters, and keep failures visible."
+    )
+    narrate(
+        text=opening,
+        output_path=output_dir / "00-opening.mp3",
+        audio=audio,
+        playback=playback,
+        base_url=base_url,
+        model=model,
+        voice=voice,
+        instructions=instructions,
+    )
+
+    for step in steps:
+        prefix = f"demo-{step.demo_id}"
+        pre_audio_path = synthesize_narration(
+            text=step.pre_narration,
+            output_path=output_dir / f"{prefix}-before.mp3",
+            audio=audio,
+            base_url=base_url,
+            model=model,
+            voice=voice,
+            instructions=instructions,
+        )
+
+        log_path = output_dir / f"{prefix}.log"
+        result, returncode = _run_step_with_overlap(
+            step=step,
+            pre_audio_path=pre_audio_path,
+            log_path=log_path,
+            dry_run=dry_run,
+            audio=audio,
+            playback=playback,
+            overlap=overlap,
+        )
+
+        post_text = step.post_success if result == "passed" else step.post_failure
+        narrate(
+            text=post_text,
+            output_path=output_dir / f"{prefix}-after.mp3",
+            audio=audio,
+            playback=playback,
+            base_url=base_url,
+            model=model,
+            voice=voice,
+            instructions=instructions,
+        )
+
+        report["steps"].append(
+            {
+                **asdict(step),
+                "result": result,
+                "returncode": returncode,
+                "log_path": str(log_path),
+            }
+        )
+
+    closing = (
+        "The live walkthrough is complete. Use the manifest and logs as the audit "
+        "trail for which claims were demonstrated live and which were only planned "
+        "or skipped."
+    )
+    narrate(
+        text=closing,
+        output_path=output_dir / "99-closing.mp3",
+        audio=audio,
+        playback=playback,
+        base_url=base_url,
+        model=model,
+        voice=voice,
+        instructions=instructions,
+    )
+
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output_dir = args.output_dir or timestamped_output_dir()
+    skip = set(args.skip_demo)
+    steps = [
+        step
+        for step in build_demo_steps(include_pr_worktree=args.include_pr_worktree)
+        if step.demo_id not in skip
+    ]
+    report = execute_demo_steps(
+        steps=steps,
+        output_dir=output_dir,
+        dry_run=args.dry_run,
+        audio=not args.no_audio,
+        playback=not args.no_playback,
+        base_url=args.base_url,
+        model=args.model,
+        voice=args.voice,
+        instructions=args.instructions,
+        overlap=not args.no_overlap,
+    )
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/demo-presenter/scripts/speak_demo.py
+++ b/.claude/skills/demo-presenter/scripts/speak_demo.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+DEFAULT_MODEL = "gpt-4o-mini-tts"
+DEFAULT_VOICE = "coral"
+DEFAULT_INSTRUCTIONS = (
+    "Speak in a warm, confident, technical presentation style. "
+    "Keep the pacing clear for a live research demo."
+)
+DEFAULT_MAX_CHARS = 3500
+SUPPORTED_FORMATS = {"mp3", "wav", "opus", "aac", "flac"}
+
+
+class DemoSpeechParser(argparse.ArgumentParser):
+    def parse_args(self, args=None, namespace=None):
+        parsed = super().parse_args(args=args, namespace=namespace)
+        if parsed.output is None:
+            parsed.output = parsed.input.with_suffix(".mp3")
+        return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = DemoSpeechParser(
+        description="Turn an AutoQEC demo narration script into spoken audio."
+    )
+    parser.add_argument("input", type=Path, help="Plain-text narration script.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output audio path. Defaults to <input>.mp3.",
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--voice", default=DEFAULT_VOICE)
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="OpenAI-compatible API base URL. Defaults to OPENAI_BASE_URL.",
+    )
+    parser.add_argument("--instructions", default=DEFAULT_INSTRUCTIONS)
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=DEFAULT_MAX_CHARS,
+        help="Maximum characters per TTS request.",
+    )
+    return parser
+
+
+def normalize_text(text: str) -> str:
+    return " ".join(text.split())
+
+
+def chunk_text(text: str, max_chars: int = DEFAULT_MAX_CHARS) -> list[str]:
+    normalized = normalize_text(text)
+    if not normalized:
+        raise ValueError("input text is empty")
+    if max_chars < 1:
+        raise ValueError("--max-chars must be positive")
+
+    words = normalized.split(" ")
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for word in words:
+        if len(word) > max_chars:
+            raise ValueError(f"single word exceeds max_chars: {word[:40]!r}")
+        added_len = len(word) if not current else len(word) + 1
+        if current and current_len + added_len > max_chars:
+            chunks.append(" ".join(current))
+            current = [word]
+            current_len = len(word)
+        else:
+            current.append(word)
+            current_len += added_len
+
+    if current:
+        chunks.append(" ".join(current))
+    return chunks
+
+
+def response_format_for(output: Path) -> str:
+    suffix = output.suffix.lower().lstrip(".")
+    return suffix if suffix in SUPPORTED_FORMATS else "mp3"
+
+
+def get_env_var(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value:
+        return value
+    if os.name != "nt":
+        return None
+    try:
+        import winreg
+
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment") as key:
+            registry_value, _ = winreg.QueryValueEx(key, name)
+            return registry_value or None
+    except OSError:
+        return None
+
+
+def resolve_base_url(cli_base_url: str | None) -> str | None:
+    return cli_base_url or get_env_var("OPENAI_BASE_URL")
+
+
+def create_client(base_url: str | None = None):
+    api_key = get_env_var("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise RuntimeError("Python package 'openai' is not installed") from exc
+    resolved_base_url = resolve_base_url(base_url)
+    if resolved_base_url:
+        return OpenAI(api_key=api_key, base_url=resolved_base_url)
+    return OpenAI(api_key=api_key)
+
+
+def synthesize_chunk(
+    *,
+    client,
+    text: str,
+    output: Path,
+    model: str,
+    voice: str,
+    instructions: str,
+    response_format: str,
+) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with client.audio.speech.with_streaming_response.create(
+        model=model,
+        voice=voice,
+        input=text,
+        instructions=instructions,
+        response_format=response_format,
+    ) as response:
+        response.stream_to_file(output)
+
+
+def concat_with_ffmpeg(part_paths: list[Path], output: Path) -> bool:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        return False
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        list_path = Path(tmp_dir) / "audio_parts.txt"
+        lines = [f"file '{path.as_posix()}'" for path in part_paths]
+        list_path.write_text("\n".join(lines), encoding="utf-8")
+        subprocess.run(
+            [
+                ffmpeg,
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(list_path),
+                "-c",
+                "copy",
+                str(output),
+            ],
+            check=True,
+        )
+    return True
+
+
+def write_playlist(part_paths: list[Path], output: Path) -> Path:
+    playlist = output.with_suffix(".m3u")
+    playlist.write_text(
+        "\n".join(path.name for path in part_paths) + "\n",
+        encoding="utf-8",
+    )
+    return playlist
+
+
+def synthesize_script(args: argparse.Namespace) -> list[Path]:
+    text = args.input.read_text(encoding="utf-8")
+    chunks = chunk_text(text, max_chars=args.max_chars)
+    response_format = response_format_for(args.output)
+    client = create_client(base_url=args.base_url)
+
+    if len(chunks) == 1:
+        synthesize_chunk(
+            client=client,
+            text=chunks[0],
+            output=args.output,
+            model=args.model,
+            voice=args.voice,
+            instructions=args.instructions,
+            response_format=response_format,
+        )
+        return [args.output]
+
+    part_paths = [
+        args.output.with_name(
+            f"{args.output.stem}.part{idx:02d}{args.output.suffix or '.mp3'}"
+        )
+        for idx in range(1, len(chunks) + 1)
+    ]
+    for chunk, part_path in zip(chunks, part_paths, strict=True):
+        synthesize_chunk(
+            client=client,
+            text=chunk,
+            output=part_path,
+            model=args.model,
+            voice=args.voice,
+            instructions=args.instructions,
+            response_format=response_format,
+        )
+
+    if concat_with_ffmpeg(part_paths, args.output):
+        return [args.output, *part_paths]
+    return [write_playlist(part_paths, args.output), *part_paths]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        outputs = synthesize_script(args)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print("AI-generated voice disclosure: tell listeners this narration is AI-generated.")
+    for output in outputs:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,10 @@ Orchestration writes **only** at the run root; the Runner writes **only** inside
 
 When developing a new skill or subagent: put the `.md` alongside the existing ones; read from `memory.py::l3_for_<role>` for context assembly; use `autoqec.agents.dispatch.build_prompt` so the Tier-2 validator rules and schema constraints are surfaced to the model.
 
+## Code Review Output
+
+PR reviews (whether triggered by `/code-review`, `/codex-review`, or any other review skill) MUST be posted directly as a comment on the GitHub PR via `gh pr comment <N> --body-file <tmp>` (or `--body`). Do NOT leave local review markdown files in `.claude/PRPs/reviews/`, `docs/`, or anywhere else in the repo. If a skill defaults to writing a local file, write to a temp path, post it, and delete it. The PR thread is the single source of truth for review feedback.
+
 ## Commit Convention
 
 Conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `ci:`.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Rules:
 
 ## Architecture at a glance
 
+The classical backend guarantees structural validity; the predecoder contributes `Δ_LER = LER(plain_classical) − LER(predecoder + classical)` — a single clean number per round.
+
 ```
 syndrome + code DEM
         │
@@ -108,15 +110,63 @@ syndrome + code DEM
  logical correction
 ```
 
-The classical backend guarantees structural validity; the predecoder contributes `Δ_LER = LER(plain_classical) − LER(predecoder + classical)` — a single clean number per round.
+Each round is a 3-subagent DAG (+ optional Verifier). Roles are backend-pluggable via `AUTOQEC_{IDEATOR,CODER,ANALYST}_BACKEND`; the Runner is local-only and enforces a tool whitelist (`autoqec/runner/safety.py`) so reward-hacking paths to training-set syndromes are physically blocked.
 
-Per-round isolation and the Pareto-as-branches model are specified in
-[`spec §15`](docs/superpowers/specs/2026-04-20-autoqec-design.md#15-worktree-based-experiment-model).
-Each round runs on its own `exp/<run_id>/<NN>-<slug>` git branch inside a
-`.worktrees/` checkout, Pareto members are the complete non-dominated
-set of VERIFIED branches, and compose rounds test `git merge parent-A
-parent-B` as a first-class scientific probe. Startup reconciliation
-(§15.10) keeps `history.jsonl` and the live branch set in sync.
+```
+ round N dispatch · fork_graph + machine_state
+        ↓
+┌─────────────────────────────────────────┐
+│ Ideator                     (subagent)  │
+│   hypothesis + fork_from + compose_mode │
+└─────────────────────────────────────────┘
+        ↓
+┌─────────────────────────────────────────┐
+│ Coder                       (subagent)  │
+│   DSL config + commit_message           │
+│   Tier-1 canonical · Tier-2 custom_fn   │
+└─────────────────────────────────────────┘
+        ↓
+┌─────────────────────────────────────────┐
+│ Runner                       (script)   │
+│   train + eval → RoundMetrics           │
+└─────────────────────────────────────────┘
+        ↓
+┌─────────────────────────────────────────┐
+│ Analyst                     (subagent)  │
+│   verdict: candidate | ignore           │
+└─────────────────────────────────────────┘
+        ↓   (if candidate)
+┌─────────────────────────────────────────┐
+│ Verifier           (optional subagent)  │
+│   VERIFIED → Pareto admit               │
+│   SUSPICIOUS / FAILED → rejected        │
+└─────────────────────────────────────────┘
+```
+
+Each round runs on its own `exp/<run_id>/<NN>-<slug>` git branch inside a `.worktrees/` checkout, Pareto members are the complete non-dominated set of VERIFIED branches, and compose rounds test `git merge parent-A parent-B` as a first-class scientific probe. Startup reconciliation keeps `history.jsonl` and the live branch set in sync.
+
+```
+ main  (f51cfcf · run_id = demo38-…103750)
+   │
+   ├─ 01-idea-a           ★ Δ=+0.18  ──┐
+   │                                   │
+   ├─ 02-idea-b           ★ Δ=+0.12  ──┤   git merge   (compose_mode = merge)
+   │                                   │
+   ├─ 03-compose-ab       ★ Δ=+0.22  ──┘   dominates both parents
+   │
+   ├─ 04-idea-c           ignore          Analyst: Δ within bootstrap CI
+   │
+   ├─ 90-conflict-L       ◇ compose_conflict · branch=None · sha=None
+   ├─ 91-conflict-R       ◇ compose_conflict · merge refused · no worktree
+   │
+   └─ 07-orphan           ⊘ orphaned_branch  · healed by reconcile
+
+ ★ on non-dominated Pareto    ◇ merge refused    ⊘ orphan recovered on startup
+ each  exp/<run_id>/<NN>-<slug>  ≡ its own  .worktrees/exp-…/  checkout
+ runs/<run_id>/  stores   history.jsonl · pareto.json · fork_graph.json (this tree)
+```
+
+
 
 ## Deliverables
 
@@ -147,7 +197,7 @@ Four ship as runnable demos. The `/add-env` demo (D3) stays planned — the CLI 
 
 ### Skills (LLM-reasoning user surfaces, exposed as `/<name>`)
 
-All five skills under `.claude/skills/` are discoverable from Claude Code. `/add-env` remained a CLI-only subcommand; `/read-zulip` was added to recover off-repo hackathon context.
+All six skills under `.claude/skills/` are discoverable from Claude Code. `/add-env` remained a CLI-only subcommand; `/read-zulip` was added to recover off-repo hackathon context.
 
 | Skill | Purpose | Status |
 |---|---|---|
@@ -155,6 +205,7 @@ All five skills under `.claude/skills/` are discoverable from Claude Code. `/add
 | `/verify-decoder` | Audit a Pareto candidate against holdout seeds (wraps `cli.autoqec verify`) | **implemented** |
 | `/review-log` | Read an entire `runs/<id>/log.md`, flag stuck hypotheses / overfitting | **implemented** |
 | `/diagnose-failure` | Root-cause a broken or stalled round, recommend a fix (wraps `cli.autoqec diagnose`) | **implemented** |
+| `/demo-presenter` | Generate an evidence-backed walkthrough and live AI narration for the merged demos plus planned PR-only worktree demo | **implemented** |
 | `/read-zulip` | Pull Zulip stream/topic history for off-repo project context | **implemented** |
 | `/add-env` | Interactively create a new env YAML | planned (CLI only for now: `python -m cli.autoqec add-env`) |
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ AutoQEC is an LLM-agent-driven auto-research harness for discovering **neural pr
 
 ## ⚡ Review in one prompt
 
-Clone the repo, open a Claude Code / Codex CLI in the project root, and paste the block below verbatim. The agent will install deps, run the four headline demos, and hand back a pass/fail table. Total wall-clock on CPU-only hardware: **~10–15 min** (skip step 0's unit suite if you're in a hurry — ~3 min off).
+Clone the repo, open a Claude Code / Codex CLI in the project root, and paste the block below verbatim. The agent will install deps, run the six headline demos, and hand back a pass/fail table. Total wall-clock on CPU-only hardware: **~15–20 min** (skip step 0's unit suite if you're in a hurry — ~3 min off).
 
 ````text
-Run the 4 demos below in order and report results. All commands run from the
+Run the 6 demos below in order and report results. All commands run from the
 repo root. First create and activate .venv (Windows: `.venv\Scripts\activate`,
 Unix: `source .venv/bin/activate`), then `pip install -e '.[dev]'`. Do NOT
 enter the live-LLM path (nested CLI sessions are unstable). For each step
@@ -43,15 +43,32 @@ criteria. At the end give one markdown summary table.
    the env config uses `classical_backend: osd` (prove the backend actually
    switched away from the surface-code MWPM path).
 
-3. Demo 4 — reward-hacking rejection (~1 min, memorizer must be rejected):
+3. Demo 3 — worktree branches-as-Pareto provenance (~30 s, no LLM):
+   `bash demos/demo-3-worktree-provenance/run.sh`
+   Pass criteria: three `run-round` invocations all exit 0; every
+   `metrics.json` has a non-empty `branch` and a real `commit_sha`; the
+   compose worktree contains both `round_1/round_1_pointer.json` and
+   `round_2/round_2_pointer.json` (proving both parents merged); the
+   deliberate-conflict step yields `status="compose_conflict"` with
+   `conflicting_files` populated.
+
+4. Demo 4 — reward-hacking rejection (~1 min, memorizer must be rejected):
    `bash demos/demo-4-reward-hacking/run.sh`
    Pass criteria: `runs/demo-4/round_0/verification_report.json.verdict` is in
    {SUSPICIOUS, FAILED} — never VERIFIED; script exits 0.
 
-4. Demo 5 — failure root-cause diagnosis (~5 s):
+5. Demo 5 — failure root-cause diagnosis (~5 s):
    `bash demos/demo-5-failure-recovery/run.sh`
    Pass criteria: stdout JSON contains `"status": "compile_error"` and a
    `status_reason` field.
+
+6. Demo 6 — advisor replay / offline reproducibility (~2 min):
+   `bash demos/demo-6-advisor-replay/run.sh`
+   Pass criteria: `cli.autoqec package-run` produces a `runs/<run_id>.tar.gz`
+   archive; `autoqec.tools.advisor_replay` extracts it under
+   `runs/demo-6-replay/` and re-runs `cli.autoqec verify` with all
+   `AUTOQEC_*_BACKEND` env vars unset and sockets blocked; the offline
+   replay verify exits 0.
 
 Summary table columns: demo | cmd | wall-clock | key artifact | pass/fail.
 Rules:
@@ -64,14 +81,16 @@ Rules:
   failed, end with "needs triage: <which step>".
 ````
 
-**What the four demos prove, in plain language:**
+**What the six demos prove, in plain language:**
 
 | Demo | Answer it gives the reviewer |
 |---|---|
 | 1 — `surface_d5` no-LLM smoke | The full round pipeline (DSL → train → eval → Pareto → `fork_graph.json`) actually writes every artifact, with `Δ_LER` reported on the surface-code path. |
 | 2 — `bb72` qLDPC | The same harness swaps MWPM → OSD cleanly; `(code, noise, constraints)` is really the only input knob. |
+| 3 — Worktree provenance | Branches-as-Pareto isn't paperware — every round commits its `round_<N>_pointer.json` into a real `exp/<run_id>/<NN>-<slug>` branch, compose rounds `git merge` two parents end-to-end, and conflict is recorded as `status="compose_conflict"` rather than thrown. |
 | 4 — Reward-hacking detection | A hand-built memorizer cheater gets **rejected** (`SUSPICIOUS` or `FAILED`), never admitted to Pareto — the independent verifier actually guards the front. |
 | 5 — Failure recovery | `cli.autoqec diagnose` takes a broken round dir and emits a machine-readable root cause (`compile_error` + reason), feeding the `/diagnose-failure` skill. |
+| 6 — Advisor replay | A run can be packaged (`cli.autoqec package-run` → `.tar.gz`) and replayed offline in a clean directory with all `AUTOQEC_*_BACKEND` env vars unset and sockets blocked — proving runs are network-free reproducible artifacts, not just local state. |
 
 > The live-LLM research loop (`/autoqec-run`) is intentionally out of the one-prompt flow — nesting Claude-Code-inside-Claude-Code is unstable. See [`docs/verification/human-verification-report-2026-04-24.md`](docs/verification/human-verification-report-2026-04-24.md) for the last end-to-end retest and [`.claude/skills/autoqec-run/SKILL.md`](.claude/skills/autoqec-run/SKILL.md) for the manual path.
 
@@ -183,27 +202,29 @@ All six are present on `main`; the one-prompt flow above exercises F1–F6 end-t
 | **F5** | Pareto-front maintenance across (Δ_LER, FLOPs, n_params) with verify-admitted candidates | **implemented** | `autoqec/pareto/front.py` + `orchestration/round_recorder.py`; atomic `pareto.json` swap covered by `tests/test_pareto_atomic*.py` |
 | **F6** | Worktree-based experiment model (branches-as-Pareto; compose rounds; startup reconciliation; `fork_graph.json`) | **implemented** | `autoqec/orchestration/{worktree,subprocess_runner,reconcile,fork_graph}.py`; persistence proven by `tests/test_fork_graph_persist.py` |
 
-### 5 Demos (each produces a reproducible artifact)
+### 6 Demos (each produces a reproducible artifact)
 
-Four ship as runnable demos. The `/add-env` demo (D3) stays planned — the CLI subcommand exists (`python -m cli.autoqec add-env …`) but no packaged demo directory yet.
+All six ship as runnable demos. The `/add-env` onboarding flow stays a CLI-only subcommand for now (`python -m cli.autoqec add-env …`) and is tracked under Skills below rather than as a demo.
 
 | # | Demo | Proves | Priority | Status |
 |---|---|---|---|---|
 | **D1** | `surface_d5` full research run — `demos/demo-1-surface-d5/run_quick.sh` | End-to-end harness works | **P0** | **implemented** |
 | **D2** | `bb72` qLDPC research run — `demos/demo-2-bb72/run.sh` (fast/dev/prod modes) | Genericity across codes / classical backends (MWPM → OSD) | P1 | **implemented** |
-| **D3** | `/add-env` onboarding | Non-coder can add environments | P2 | planned (CLI ready, demo dir pending) |
+| **D3** | Worktree branches-as-Pareto provenance — `demos/demo-3-worktree-provenance/run.sh` | Every round runs in its own `exp/<run_id>/<NN>-<slug>` git worktree, commits a `round_<N>_pointer.json`, and `compose_conflict` is a recorded failure mode (issue #38) | P1 | **implemented** |
 | **D4** | Reward-hacking detection — `demos/demo-4-reward-hacking/run.sh` | Memorizer cheater gets `SUSPICIOUS` / `FAILED` verdict | **P0** | **implemented** |
 | **D5** | Failure recovery — `demos/demo-5-failure-recovery/run.sh` | `cli.autoqec diagnose` identifies `compile_error` root cause | P2 | **implemented** |
+| **D6** | Advisor replay / offline reproducibility — `demos/demo-6-advisor-replay/run.sh` | A packaged run replays under `runs/demo-6-replay/` with no LLM backends and no network — `cli.autoqec package-run` + `autoqec.tools.advisor_replay` | P2 | **implemented** |
 
 ### Skills (LLM-reasoning user surfaces, exposed as `/<name>`)
 
-All six skills under `.claude/skills/` are discoverable from Claude Code. `/add-env` remained a CLI-only subcommand; `/read-zulip` was added to recover off-repo hackathon context.
+All six skills under `.claude/skills/` are discoverable from Claude Code. `/add-env` remained a CLI-only subcommand; `/read-zulip` recovers off-repo hackathon context; `/review-framework` closes the autoresearch loop by feeding findings from a completed run back into the codebase.
 
 | Skill | Purpose | Status |
 |---|---|---|
 | `/autoqec-run` | Run the full research loop on an env YAML | **implemented** |
 | `/verify-decoder` | Audit a Pareto candidate against holdout seeds (wraps `cli.autoqec verify`) | **implemented** |
 | `/review-log` | Read an entire `runs/<id>/log.md`, flag stuck hypotheses / overfitting | **implemented** |
+| `/review-framework` | Read a completed run and propose framework improvements (DSL gaps, weak baselines, prompt drift, env limits, orchestration friction); advisory only, never edits framework code | **implemented** |
 | `/diagnose-failure` | Root-cause a broken or stalled round, recommend a fix (wraps `cli.autoqec diagnose`) | **implemented** |
 | `/demo-presenter` | Generate an evidence-backed walkthrough and live AI narration for the merged demos plus planned PR-only worktree demo | **implemented** |
 | `/read-zulip` | Pull Zulip stream/topic history for off-repo project context | **implemented** |
@@ -227,8 +248,8 @@ qec-ai-decoder/
 ├── cli/autoqec.py                  # click CLI entry
 ├── .claude/
 │   ├── agents/                     # Subagent prompt files
-│   └── skills/                     # 5 user-facing skills
-├── demos/                          # 5 demos with run.sh + walkthrough.md
+│   └── skills/                     # 6 user-facing skills
+├── demos/                          # 6 demos with run.sh + (some) walkthrough.md
 ├── envs/                           # User-authored env YAMLs
 ├── circuits/                       # *.stim files
 ├── runs/                           # .gitignore'd; per-run outputs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        informational: true
+
+  precision: 2
+  round: down
+  range: "70...90"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "tests/"
+  - "scripts/"
+  - "demos/"
+  - "docs/"
+  - "knowledge/"
+  - "**/__init__.py"

--- a/demos/_lib/python_bin.sh
+++ b/demos/_lib/python_bin.sh
@@ -1,0 +1,41 @@
+# Shared helper for demo bash launchers.
+#
+# `discover_demo_python <start_dir>` echoes the absolute path of the
+# project's `.venv` interpreter if one is found by walking up from
+# `<start_dir>`, otherwise falls back to `python3` then `python`. This
+# matches the Python-side resolver in scripts/run_bb72_demo.py so Demo 1
+# and Demo 4 pick up the project venv even when the caller's PATH points
+# at a system Python that lacks torch.
+#
+# Usage:
+#   HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+#   source "$REPO_ROOT/demos/_lib/python_bin.sh"
+#   PY="${PYTHON:-$(discover_demo_python "$REPO_ROOT")}"
+
+discover_demo_python() {
+    local d="$1"
+    while [[ -n "$d" && "$d" != "/" && "$d" != "." ]]; do
+        # -f rather than -x so Windows (where Python's os.chmod cannot set
+        # Unix exec bits) still resolves a freshly-created .venv correctly.
+        if [[ -f "$d/.venv/Scripts/python.exe" ]]; then
+            printf '%s\n' "$d/.venv/Scripts/python.exe"
+            return 0
+        fi
+        if [[ -f "$d/.venv/bin/python" ]]; then
+            printf '%s\n' "$d/.venv/bin/python"
+            return 0
+        fi
+        local parent
+        parent="$(dirname "$d")"
+        if [[ "$parent" == "$d" ]]; then
+            break
+        fi
+        d="$parent"
+    done
+    if command -v python3 >/dev/null 2>&1; then
+        printf '%s\n' "python3"
+        return 0
+    fi
+    printf '%s\n' "python"
+}

--- a/demos/demo-1-surface-d5/run_quick.sh
+++ b/demos/demo-1-surface-d5/run_quick.sh
@@ -6,11 +6,17 @@
 # a Claude Code session. See demos/demo-1-surface-d5/README.md.
 set -euo pipefail
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/demos/_lib/python_bin.sh"
+PY="${PYTHON:-$(discover_demo_python "$REPO_ROOT")}"
+
 ROUNDS="${ROUNDS:-3}"
 PROFILE="${PROFILE:-dev}"
 ENV_YAML="${ENV_YAML:-autoqec/envs/builtin/surface_d5_depol.yaml}"
 
-python -m cli.autoqec run "$ENV_YAML" \
+"$PY" -m cli.autoqec run "$ENV_YAML" \
     --rounds "$ROUNDS" \
     --profile "$PROFILE" \
     --no-llm

--- a/demos/demo-4-reward-hacking/README.md
+++ b/demos/demo-4-reward-hacking/README.md
@@ -29,6 +29,32 @@ bash demos/demo-4-reward-hacking/run.sh
 bash demos/demo-4-reward-hacking/run.sh --full
 ```
 
+### Narrated walkthrough (for advisor / hackathon demos)
+
+```bash
+bash demos/demo-4-reward-hacking/present.sh
+```
+
+Same CI semantics as `run.sh` (exits 0 iff the cheat is rejected), but
+the output is split into five labeled phases with ASCII bar charts and
+a matplotlib scoreboard PNG under
+`runs/demo-4/round_0/visualizations/scoreboard.png`. Phases:
+
+1. **Construct cheat** — memorizes (syndrome → correction) pairs from
+   training-seed shots; prints table size.
+2. **Hit-rate scoreboard** — bars for *memorized* / *fresh-train* /
+   *holdout* probes. Reveals the cheat is bound to specific shots, not
+   to seed ranges (fresh-train ≈ holdout hit rate).
+3. **Fair-test LER** — plain MWPM vs memorizer on holdout, with 95% CI.
+4. **Three-guard checklist** — seed-leakage, paired bootstrap CI,
+   ablation sanity. Usually `paired bootstrap CI` trips for this cheat.
+5. **Verdict banner + Pareto consequence** — `FAILED` / `SUSPICIOUS`
+   rejection with a one-line description of how the branch would be
+   tagged in `fork_graph.json`.
+
+`present_summary.json` alongside the other round artifacts records the
+phase-by-phase numbers for post-hoc analysis.
+
 The script:
 
 1. Instantiates `MemorizerPredecoder` and fills its lookup table from the

--- a/demos/demo-4-reward-hacking/present.py
+++ b/demos/demo-4-reward-hacking/present.py
@@ -1,0 +1,449 @@
+"""Narrated, visualized walkthrough of the reward-hacking demo.
+
+Unlike ``run.sh`` (which only prints the final verdict), this script breaks
+the demo into five phases with ASCII bar charts + an optional matplotlib
+PNG so a presenter can narrate what the hacking example is, how it was
+detected, and what the Pareto consequence is.
+
+Phases:
+  1. Construct the memorizing cheater from training-seed syndromes.
+  2. Show lookup-table hit rate on train seeds vs holdout seeds.
+  3. Run the independent verifier -> holdout LER vs plain MWPM.
+  4. Render the three verifier guards as a checklist.
+  5. Print the verdict banner and the Pareto consequence.
+
+Exits 0 when the verifier correctly rejects the cheat (verdict in
+{FAILED, SUSPICIOUS}); non-zero if the cheat would have been VERIFIED.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from autoqec.cheaters.memorize import MemorizerPredecoder, train_memorizer  # noqa: E402
+from autoqec.envs.schema import load_env_yaml  # noqa: E402
+from autoqec.eval.independent_eval import independent_verify  # noqa: E402
+from autoqec.runner.data import load_code_artifacts, sample_syndromes  # noqa: E402
+
+
+BAR_WIDTH = 34
+
+
+@dataclass(frozen=True)
+class _PhaseTwoStats:
+    seen_hit_rate: float
+    fresh_train_hit_rate: float
+    holdout_hit_rate: float
+    n_probes: int
+
+
+def _display_path(path: Path) -> str:
+    """Relative to repo if possible, absolute otherwise -- for log lines that
+    want short paths in the common case but must not crash when --run-dir
+    points outside the repo (e.g. tests using tmp_path)."""
+    try:
+        return str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _ascii_bar(value: float, vmax: float, width: int = BAR_WIDTH) -> str:
+    if vmax <= 0:
+        return "." * width
+    frac = max(0.0, min(1.0, value / vmax))
+    filled = int(round(frac * width))
+    return "#" * filled + "." * (width - filled)
+
+
+def _phase_header(title: str, subtitle: str = "") -> None:
+    print()
+    print("=" * 72)
+    print(f"  {title}")
+    if subtitle:
+        print(f"  {subtitle}")
+    print("=" * 72)
+
+
+def phase1_construct_cheat(
+    env, artifacts, run_dir: Path, n_shots: int
+) -> tuple[dict, MemorizerPredecoder, np.ndarray]:
+    _phase_header(
+        "PHASE 1 - Construct the memorizing cheater",
+        "Reads train-seed syndromes and builds a lookup table (syndrome -> perfect correction).",
+    )
+    mem = train_memorizer(env, artifacts, n_shots=n_shots)
+
+    # Pull the exact syndromes we just memorized so phase 2 can probe the
+    # "seen" bucket accurately. Re-sampling here would give a different set;
+    # we store the key list from the table itself.
+    seen_keys = np.array(list(mem.table.keys()), dtype=np.int64)
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = run_dir / "checkpoint.pt"
+    torch.save(
+        {
+            "class_name": "MemorizerPredecoder",
+            "model": mem,
+            "state_dict": mem.state_dict(),
+            "output_mode": "hard_flip",
+            "dsl_config": None,
+        },
+        ckpt_path,
+    )
+
+    n_unique = len(mem.table)
+    train_lo, train_hi = env.noise.seed_policy.train
+    print()
+    print(f"  memorized {n_unique:,d} unique (syndrome -> correction) pairs")
+    print(f"  drawn from training seeds [{train_lo}..{train_hi}]  (n_shots={n_shots:,d})")
+    print(f"  saved checkpoint:  {_display_path(ckpt_path)}")
+    print()
+    print("  This cheater will ace any syndrome it has literally seen. The")
+    print("  interesting question is whether 'train seed range' is enough")
+    print("  shared structure for it to generalize, or whether the cheat is")
+    print("  bound to exact shots. Phase 2 answers that.")
+    info = {
+        "n_unique_entries": n_unique,
+        "train_seed_range": [train_lo, train_hi],
+        "checkpoint_path": str(_display_path(ckpt_path)),
+    }
+    return info, mem, seen_keys
+
+
+def phase2_hit_rate(
+    env, artifacts, mem: MemorizerPredecoder, seen_keys: np.ndarray, n_probes: int
+) -> _PhaseTwoStats:
+    _phase_header(
+        "PHASE 2 - Lookup-table hit rate: memorized / fresh-train / holdout",
+        "Three probes reveal whether the cheat generalizes to seed ranges or is bound to exact shots.",
+    )
+
+    def probe(syndromes_np: np.ndarray) -> float:
+        if syndromes_np.shape[0] == 0:
+            return 0.0
+        hits = 0
+        for row in syndromes_np:
+            if tuple(row.tolist()) in mem.table:
+                hits += 1
+        return hits / syndromes_np.shape[0]
+
+    # Bucket A: shots the memorizer has literally seen (its home turf).
+    seen_sample = seen_keys if seen_keys.shape[0] <= n_probes else seen_keys[:n_probes]
+    seen_hr = probe(seen_sample)
+
+    # Bucket B: fresh draws from the same train seed range.
+    fresh_train_syn, _ = sample_syndromes(env, artifacts, env.noise.seed_policy.train, n_probes)
+    fresh_train_hr = probe(fresh_train_syn.numpy())
+
+    # Bucket C: fresh draws from the holdout seed range (the fair test).
+    holdout_syn, _ = sample_syndromes(env, artifacts, env.noise.seed_policy.holdout, n_probes)
+    holdout_hr = probe(holdout_syn.numpy())
+
+    print()
+    print(f"  {'memorized shots':<22}  {seen_hr*100:5.1f}%  [{_ascii_bar(seen_hr, 1.0)}]")
+    print(f"  {'fresh train-seed shots':<22}  {fresh_train_hr*100:5.1f}%  [{_ascii_bar(fresh_train_hr, 1.0)}]")
+    print(f"  {'holdout-seed shots':<22}  {holdout_hr*100:5.1f}%  [{_ascii_bar(holdout_hr, 1.0)}]")
+    print()
+    print("  The cheat is bound to *specific shots*, not to 'train seed range'.")
+    print(f"  Even fresh draws from seeds [{env.noise.seed_policy.train[0]}..{env.noise.seed_policy.train[1]}] only")
+    print(f"  match {fresh_train_hr*100:.0f}% of the table -- almost the same as holdout's {holdout_hr*100:.0f}%.")
+    print("  So the cheat does not cheat by leaking seeds; it cheats by overfitting")
+    print("  to exact syndromes. On misses it outputs all-zero, which poisons MWPM:")
+    print("  MWPM thinks a predecoder already solved the problem and gets a wrong hint.")
+    return _PhaseTwoStats(
+        seen_hit_rate=seen_hr,
+        fresh_train_hit_rate=fresh_train_hr,
+        holdout_hit_rate=holdout_hr,
+        n_probes=n_probes,
+    )
+
+
+def phase3_verify(env, run_dir: Path, n_shots: int, n_seeds: int) -> tuple[dict, object]:
+    _phase_header(
+        "PHASE 3 - Fair-test: independent verifier on holdout seeds",
+        "Runs the same guards an admitted Pareto candidate would have to pass.",
+    )
+    sp = env.noise.seed_policy
+    holdout_seeds = list(range(sp.holdout[0], sp.holdout[0] + n_seeds))
+    report = independent_verify(
+        checkpoint=run_dir / "checkpoint.pt",
+        env_spec=env,
+        holdout_seeds=holdout_seeds,
+        n_shots=n_shots,
+    )
+    ler_plain = float(ler_plain_from_notes(report.notes))
+    ler_pred = float(report.ler_holdout)
+    lo, hi = report.ler_holdout_ci
+
+    (run_dir / "verification_report.json").write_text(
+        report.model_dump_json(indent=2), encoding="utf-8"
+    )
+    (run_dir / "verification_report.md").write_text(_render_markdown(report, ler_plain), encoding="utf-8")
+
+    vmax = max(ler_plain, ler_pred, 0.01) * 1.15
+    print()
+    print(f"  {'plain MWPM':<16}  LER = {ler_plain:.4f}                  [{_ascii_bar(ler_plain, vmax)}]")
+    print(
+        f"  {'memorizer':<16}  LER = {ler_pred:.4f}   95%CI ({lo:.3f},{hi:.3f})"
+        f"  [{_ascii_bar(ler_pred, vmax)}]"
+    )
+    print()
+    print(f"  delta_LER (holdout)    = {report.delta_ler_holdout:+.4f}")
+    print(f"  ler_shuffled (ablation)= {report.ler_shuffled:.4f}")
+    print(f"  paired_eval_bundle_id  = {report.paired_eval_bundle_id}")
+    return {
+        "ler_plain": ler_plain,
+        "ler_pred": ler_pred,
+        "ler_ci_lo": float(lo),
+        "ler_ci_hi": float(hi),
+        "delta_ler": float(report.delta_ler_holdout),
+        "ler_shuffled": float(report.ler_shuffled),
+        "n_shots": n_shots,
+        "n_seeds": n_seeds,
+        "paired_eval_bundle_id": report.paired_eval_bundle_id,
+        "holdout_seeds_used": report.holdout_seeds_used,
+    }, report
+
+
+def phase4_guards(report, ler_plain: float) -> list[dict]:
+    _phase_header(
+        "PHASE 4 - Three independent guards",
+        "Each guard interrogates a different failure mode. Any failing guard keeps the checkpoint off the Pareto front.",
+    )
+    delta = float(report.delta_ler_holdout)
+    lo, hi = report.ler_holdout_ci
+    ci_half = (float(hi) - float(lo)) / 2
+    guards = [
+        {
+            "name": "seed-leakage hygiene",
+            "ok": bool(report.seed_leakage_check_ok),
+            "explain": "holdout seeds are strictly outside the train/val range",
+        },
+        {
+            "name": "paired bootstrap CI",
+            "ok": abs(delta) < ci_half,
+            "explain": (
+                f"delta_LER = {delta:+.4f}, CI half-width = {ci_half:.4f}; "
+                "pass = CI crosses 0; strong-negative delta triggers FAILED"
+            ),
+        },
+        {
+            "name": "ablation sanity",
+            "ok": bool(report.ablation_sanity_ok),
+            "explain": (
+                f"shuffled_LER ({report.ler_shuffled:.4f}) must not be meaningfully "
+                f"better than predecoder_LER ({report.ler_holdout:.4f})"
+            ),
+        },
+    ]
+    print()
+    for g in guards:
+        mark = "PASS" if g["ok"] else "FAIL"
+        print(f"  [{mark}] {g['name']:<26}  {g['explain']}")
+    print()
+    print("  The interesting guard here is paired-bootstrap CI: the delta is strongly")
+    print("  negative AND the CI does not cross 0, so the verifier flags the cheater.")
+    return guards
+
+
+def phase5_verdict(report, run_dir: Path) -> str:
+    _phase_header("PHASE 5 - Verdict + Pareto consequence")
+    verdict = report.verdict
+    if verdict == "VERIFIED":
+        banner = (
+            "+------------------------------------------------+\n"
+            "|  VERDICT: VERIFIED  (THIS SHOULD NEVER HAPPEN) |\n"
+            "+------------------------------------------------+"
+        )
+        consequence = "If you see this, the verifier is broken. DO NOT trust the Pareto front."
+    elif verdict == "FAILED":
+        banner = (
+            "+------------------------------------------------+\n"
+            "|  VERDICT: FAILED  (cheat correctly rejected)   |\n"
+            "+------------------------------------------------+"
+        )
+        consequence = (
+            "Pareto consequence: this checkpoint is NOT admitted to pareto.json.\n"
+            "Branch exp/<run>/<NN>-memorizer would be tagged in fork_graph.json\n"
+            "with status=rejected_by_verifier and kept around only as a negative example."
+        )
+    else:  # SUSPICIOUS
+        banner = (
+            "+---------------------------------------------------+\n"
+            "|  VERDICT: SUSPICIOUS  (cheat kept off Pareto too) |\n"
+            "+---------------------------------------------------+"
+        )
+        consequence = (
+            "Pareto consequence: this checkpoint is NOT admitted to pareto.json.\n"
+            "SUSPICIOUS means the verifier could not confidently rule in OR out;\n"
+            "admission requires a positive, CI-clear Δ_LER."
+        )
+    print()
+    print(banner)
+    print()
+    print(consequence)
+    print()
+    print(f"  report json:      {_display_path(run_dir / 'verification_report.json')}")
+    print(f"  report markdown:  {_display_path(run_dir / 'verification_report.md')}")
+    return verdict
+
+
+def ler_plain_from_notes(notes: str) -> float:
+    for part in notes.replace(",", " ").split():
+        if part.startswith("plain_ler="):
+            return float(part.split("=", 1)[1])
+    return float("nan")
+
+
+def _render_markdown(report, ler_plain: float) -> str:
+    lo, hi = report.ler_holdout_ci
+    return (
+        "# Verification Report\n\n"
+        f"**Verdict:** {report.verdict}\n\n"
+        f"- Holdout LER: {report.ler_holdout:.4f}\n"
+        f"- Holdout LER CI: ({lo:.4f}, {hi:.4f})\n"
+        f"- delta_LER (holdout): {report.delta_ler_holdout:.4f}\n"
+        f"- Ablation sanity: {report.ablation_sanity_ok}\n"
+        f"- Seed-leakage check: {report.seed_leakage_check_ok}\n"
+        f"- Paired eval bundle ID: {report.paired_eval_bundle_id}\n\n"
+        f"Notes: {report.notes}\n"
+    )
+
+
+def try_write_png(
+    run_dir: Path,
+    phase2: _PhaseTwoStats,
+    phase3: dict,
+) -> Path | None:
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:
+        print("\n  (matplotlib unavailable, skipping PNG)")
+        return None
+
+    viz_dir = run_dir / "visualizations"
+    viz_dir.mkdir(parents=True, exist_ok=True)
+    out_path = viz_dir / "scoreboard.png"
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 4.2))
+
+    hit_labels = ["memorized shots", "fresh train", "holdout"]
+    hit_values = [
+        phase2.seen_hit_rate * 100,
+        phase2.fresh_train_hit_rate * 100,
+        phase2.holdout_hit_rate * 100,
+    ]
+    ax1.bar(hit_labels, hit_values, color=["#3b7dd8", "#d8933b", "#d83b3b"])
+    ax1.set_ylabel("lookup hit rate (%)")
+    ax1.set_ylim(0, 110)
+    ax1.set_title("Memorizer table hit rate")
+    for i, v in enumerate(hit_values):
+        ax1.text(i, v + 2, f"{v:.1f}%", ha="center", fontsize=10)
+
+    lers = [phase3["ler_plain"], phase3["ler_pred"]]
+    err_lo = [0.0, max(0.0, phase3["ler_pred"] - phase3["ler_ci_lo"])]
+    err_hi = [0.0, max(0.0, phase3["ler_ci_hi"] - phase3["ler_pred"])]
+    ax2.bar(
+        ["plain MWPM", "memorizer"],
+        lers,
+        color=["#3b7dd8", "#d83b3b"],
+        yerr=[err_lo, err_hi],
+        capsize=6,
+    )
+    ax2.set_ylabel("holdout logical error rate")
+    ax2.set_title("Fair-test LER (lower is better)")
+    for i, v in enumerate(lers):
+        ax2.text(i, v + max(lers) * 0.03, f"{v:.4f}", ha="center", fontsize=10)
+
+    fig.suptitle("Reward-hacking demo scoreboard  (cheat's home turf vs fair test)")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+    print()
+    print(f"  PNG written: {_display_path(out_path)}")
+    return out_path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--env-yaml",
+        default=str(_REPO_ROOT / "autoqec/envs/builtin/surface_d5_depol.yaml"),
+    )
+    p.add_argument("--run-dir", default=str(_REPO_ROOT / "runs/demo-4/round_0"))
+    p.add_argument("--n-shots", type=int, default=5000)
+    p.add_argument("--n-seeds", type=int, default=5)
+    p.add_argument("--n-probes", type=int, default=2000)
+    p.add_argument("--memorize-shots", type=int, default=10_000)
+    p.add_argument("--no-png", action="store_true", help="Skip the matplotlib PNG.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    env = load_env_yaml(args.env_yaml)
+    artifacts = load_code_artifacts(env)
+    run_dir = Path(args.run_dir).resolve()
+
+    print("AutoQEC reward-hacking demo - narrated walkthrough")
+    print(f"env:     {args.env_yaml}")
+    print(f"run_dir: {_display_path(run_dir)}")
+    print(f"budget:  n_shots={args.n_shots}  n_seeds={args.n_seeds}  n_probes={args.n_probes}")
+
+    phase1, mem, seen_keys = phase1_construct_cheat(
+        env, artifacts, run_dir, args.memorize_shots
+    )
+    phase2 = phase2_hit_rate(env, artifacts, mem, seen_keys, args.n_probes)
+    phase3_dict, report = phase3_verify(env, run_dir, args.n_shots, args.n_seeds)
+    guards = phase4_guards(report, phase3_dict["ler_plain"])
+    verdict = phase5_verdict(report, run_dir)
+
+    png_path: Path | None = None
+    if not args.no_png:
+        png_path = try_write_png(run_dir, phase2, phase3_dict)
+
+    summary = {
+        "verdict": verdict,
+        "phase1": phase1,
+        "phase2": {
+            "seen_hit_rate": phase2.seen_hit_rate,
+            "fresh_train_hit_rate": phase2.fresh_train_hit_rate,
+            "holdout_hit_rate": phase2.holdout_hit_rate,
+            "n_probes": phase2.n_probes,
+        },
+        "phase3": phase3_dict,
+        "phase4_guards": guards,
+        "png_path": _display_path(png_path) if png_path else None,
+    }
+    (run_dir / "present_summary.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8"
+    )
+
+    # Exit semantics mirror run.sh so CI can reuse the same invocation.
+    if verdict == "VERIFIED":
+        print(
+            "\nFAILURE: memorizer was VERIFIED. The verifier is broken or the",
+            file=sys.stderr,
+        )
+        print("seed policy lets train and holdout overlap.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    # Make torch deterministic-ish for demos so the scoreboard is stable.
+    torch.manual_seed(0)
+    np.random.seed(0)
+    raise SystemExit(main())

--- a/demos/demo-4-reward-hacking/present.sh
+++ b/demos/demo-4-reward-hacking/present.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Demo 4 narrated walkthrough. Produces structured ASCII visualizations
+# plus an optional PNG scoreboard.
+#
+# Same exit semantics as run.sh: 0 when the cheat is rejected (verdict in
+# {FAILED, SUSPICIOUS}); non-zero on a VERIFIED verdict (verifier is broken).
+#
+# Env overrides:
+#   PYTHON=/path/to/python   override interpreter (else picks project .venv)
+#   AUTOQEC_ENV_YAML=...     override env YAML (defaults to surface_d5_depol)
+#   RUN_DIR=...              override run directory (defaults to runs/demo-4/round_0)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/demos/_lib/python_bin.sh"
+PY="${PYTHON:-$(discover_demo_python "$REPO_ROOT")}"
+
+ENV_YAML="${AUTOQEC_ENV_YAML:-autoqec/envs/builtin/surface_d5_depol.yaml}"
+RUN_DIR="${RUN_DIR:-runs/demo-4/round_0}"
+
+"$PY" "$HERE/present.py" \
+    --env-yaml "$ENV_YAML" \
+    --run-dir "$RUN_DIR" \
+    "$@"
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+    echo ""
+    echo "==> rendering HTML visualization"
+    "$PY" "$HERE/present_html.py" --run-dir "$RUN_DIR" || true
+fi
+
+exit $rc

--- a/demos/demo-4-reward-hacking/present_html.py
+++ b/demos/demo-4-reward-hacking/present_html.py
@@ -1,0 +1,447 @@
+"""Generate a self-contained HTML visualization of the reward-hacking demo.
+
+Reads the verifier's JSON report from a demo-4 run directory (and optionally
+the richer phase-by-phase summary produced by ``present.py``), then writes a
+static HTML file with inline SVG bar charts and opens it in the default
+browser. Designed to be invoked at the tail of ``run.sh`` / ``present.sh``.
+
+Required input
+  runs/demo-4/round_0/verification_report.json
+
+Optional input
+  runs/demo-4/round_0/present_summary.json   adds the Phase 2 hit-rate card
+
+Output
+  runs/demo-4/round_0/visualizations/index.html   (self-contained, file:// safe)
+
+Env
+  AUTOQEC_NO_OPEN=1   never auto-open the browser (use in CI / headless runs)
+  CI=true             treated the same as AUTOQEC_NO_OPEN=1
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import webbrowser
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class _Guard:
+    name: str
+    ok: bool
+    explain: str
+
+
+def _load_required_report(run_dir: Path) -> dict:
+    p = run_dir / "verification_report.json"
+    if not p.is_file():
+        raise FileNotFoundError(
+            f"verification_report.json not found at {p}. "
+            "Run demos/demo-4-reward-hacking/run.sh first."
+        )
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _load_optional_summary(run_dir: Path) -> dict | None:
+    p = run_dir / "present_summary.json"
+    if not p.is_file():
+        return None
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _plain_ler_from_notes(notes: str) -> float | None:
+    for part in notes.replace(",", " ").split():
+        if part.startswith("plain_ler="):
+            try:
+                return float(part.split("=", 1)[1])
+            except ValueError:
+                return None
+    return None
+
+
+def _derive_guards(report: dict) -> list[_Guard]:
+    delta = float(report.get("delta_ler_holdout", 0.0))
+    lo, hi = report.get("ler_holdout_ci", [0.0, 0.0])
+    ci_half = (float(hi) - float(lo)) / 2.0
+    return [
+        _Guard(
+            name="seed-leakage hygiene",
+            ok=bool(report.get("seed_leakage_check_ok", True)),
+            explain="holdout seeds are strictly outside the train/val range",
+        ),
+        _Guard(
+            name="paired bootstrap CI",
+            ok=abs(delta) < ci_half,
+            explain=(
+                f"Δ_LER = {delta:+.4f}, CI half-width = {ci_half:.4f}; "
+                "pass = CI crosses 0; strong-negative Δ triggers FAILED"
+            ),
+        ),
+        _Guard(
+            name="ablation sanity",
+            ok=bool(report.get("ablation_sanity_ok", True)),
+            explain=(
+                f"shuffled_LER ({float(report.get('ler_shuffled', 0.0)):.4f}) must not be "
+                f"meaningfully better than predecoder_LER "
+                f"({float(report.get('ler_holdout', 0.0)):.4f})"
+            ),
+        ),
+    ]
+
+
+_CSS = """
+:root{color-scheme:dark;--bg:#0f172a;--panel:#1e293b;--border:#334155;
+--text:#e2e8f0;--muted:#94a3b8;--plain:#3b7dd8;--train:#d8933b;--cheat:#d83b3b;
+--ok:#22c55e;--warn:#eab308;--bad:#b91c1c}
+*{box-sizing:border-box}
+body{margin:0;font-family:ui-sans-serif,-apple-system,"Segoe UI",sans-serif;
+background:var(--bg);color:var(--text);line-height:1.5}
+.container{max-width:1080px;margin:0 auto;padding:40px 24px 80px}
+header{margin-bottom:28px}
+h1{margin:0 0 6px;font-size:28px;font-weight:700}
+.sub{color:var(--muted);font-size:14px}
+.sub code{background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px}
+.banner{margin-top:20px;padding:16px 22px;border-radius:12px;
+display:flex;align-items:center;gap:18px;font-size:16px;flex-wrap:wrap}
+/* banner color tracks DEMO OUTCOME, not the raw verdict label:
+   FAILED = cheat rejected = GOOD (green); VERIFIED = cheat admitted = verifier broken (red). */
+.banner.FAILED{background:rgba(34,197,94,0.18);border:1px solid var(--ok)}
+.banner.SUSPICIOUS{background:rgba(234,179,8,0.18);border:1px solid var(--warn)}
+.banner.VERIFIED{background:rgba(185,28,28,0.22);border:1px solid var(--bad)}
+.pill{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px;
+font-weight:700;letter-spacing:0.04em;padding:4px 10px;border-radius:999px;
+background:rgba(0,0,0,0.35);text-transform:uppercase}
+.banner.FAILED .pill{color:#bbf7d0}
+.banner.SUSPICIOUS .pill{color:#fde68a}
+.banner.VERIFIED .pill{color:#fecaca}
+.grid{display:grid;gap:18px;grid-template-columns:repeat(2,1fr)}
+.grid.full{grid-template-columns:1fr;margin-top:18px}
+@media(max-width:720px){.grid{grid-template-columns:1fr}}
+.card{background:var(--panel);border:1px solid var(--border);border-radius:12px;
+padding:20px 22px}
+.card h2{margin:0 0 4px;font-size:13px;font-weight:700;text-transform:uppercase;
+letter-spacing:0.08em;color:var(--muted)}
+.card h3{margin:0 0 12px;font-size:18px;font-weight:600}
+.card p{margin:0 0 8px;font-size:14px}
+.card p:last-child{margin-bottom:0}
+.card .note{color:var(--muted);font-size:13px;font-style:italic}
+.card code{font-family:ui-monospace,Menlo,Consolas,monospace;
+background:rgba(255,255,255,0.06);padding:1px 5px;border-radius:4px;font-size:12.5px}
+.bar-row{display:grid;grid-template-columns:150px 1fr 210px;align-items:center;
+gap:12px;margin-bottom:8px}
+.bar-label{font-size:13px;color:var(--muted)}
+.bar-value{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px;
+text-align:right}
+.bar-track{background:rgba(255,255,255,0.06);border-radius:6px;
+position:relative;height:22px}
+.bar-fill{height:22px;border-radius:6px;display:block}
+.bar-fill.plain{background:var(--plain)}
+.bar-fill.train{background:var(--train)}
+.bar-fill.cheat{background:var(--cheat)}
+.bar-ci{position:absolute;top:3px;bottom:3px;pointer-events:none;
+border-left:2px solid rgba(255,255,255,0.85);
+border-right:2px solid rgba(255,255,255,0.85)}
+.bar-ci::before{content:"";position:absolute;top:50%;left:0;right:0;
+border-top:1px solid rgba(255,255,255,0.85)}
+.guards{display:flex;flex-direction:column;gap:10px}
+.guard{display:grid;grid-template-columns:68px 1fr;gap:14px;padding:10px 12px;
+border-radius:8px;background:rgba(0,0,0,0.25)}
+.guard .tag{font-family:ui-monospace,Menlo,Consolas,monospace;font-weight:700;
+font-size:12px;text-align:center;padding:5px 0;border-radius:4px;align-self:start}
+.guard .tag.pass{background:rgba(34,197,94,0.18);color:#86efac}
+.guard .tag.fail{background:rgba(185,28,28,0.22);color:#fca5a5}
+.guard .name{font-weight:600;font-size:14px}
+.guard .explain{color:var(--muted);font-size:12.5px;margin-top:2px;
+font-family:ui-monospace,Menlo,Consolas,monospace}
+.kv{display:grid;grid-template-columns:auto 1fr;gap:6px 18px;font-size:13px;
+margin-top:14px}
+.kv dt{color:var(--muted)}
+.kv dd{margin:0;font-family:ui-monospace,Menlo,Consolas,monospace;
+word-break:break-all}
+footer{margin-top:36px;color:var(--muted);font-size:12px;text-align:center}
+footer code{font-family:ui-monospace,Menlo,Consolas,monospace}
+footer a{color:var(--muted);text-decoration:underline dotted}
+footer .row{margin-top:6px}
+"""
+
+
+def _bar_row(label: str, value: float, vmax: float, color_cls: str, rhs: str) -> str:
+    frac = 0.0 if vmax <= 0 else max(0.0, min(1.0, value / vmax))
+    return (
+        f'<div class="bar-row">'
+        f'<div class="bar-label">{html.escape(label)}</div>'
+        f'<div class="bar-track"><span class="bar-fill {color_cls}" '
+        f'style="width:{frac * 100:.2f}%"></span></div>'
+        f'<div class="bar-value">{html.escape(rhs)}</div>'
+        f"</div>"
+    )
+
+
+def _bar_row_with_ci(
+    label: str, value: float, ci_lo: float, ci_hi: float, vmax: float,
+    color_cls: str, rhs: str,
+) -> str:
+    def pct(v: float) -> float:
+        return 0.0 if vmax <= 0 else max(0.0, min(1.0, v / vmax)) * 100
+    w, lo, hi = pct(value), pct(ci_lo), pct(ci_hi)
+    ci_w = max(0.0, hi - lo)
+    return (
+        f'<div class="bar-row">'
+        f'<div class="bar-label">{html.escape(label)}</div>'
+        f'<div class="bar-track">'
+        f'<span class="bar-fill {color_cls}" style="width:{w:.2f}%"></span>'
+        f'<span class="bar-ci" style="left:{lo:.2f}%;width:{ci_w:.2f}%"></span>'
+        f"</div>"
+        f'<div class="bar-value">{html.escape(rhs)}</div>'
+        f"</div>"
+    )
+
+
+def _intro_card() -> str:
+    return """
+    <section class="card">
+      <h2>Phase 1 · what is reward hacking here?</h2>
+      <h3>Memorize training syndromes. Ace the train set. Fail the fair test.</h3>
+      <p>The <strong>MemorizerPredecoder</strong> cheat reads syndromes from the
+      <em>training seed range</em>, builds a lookup table
+      <code>(syndrome &rarr; perfect correction)</code>, and returns the stored
+      correction at inference time. On its home turf it looks flawless.</p>
+      <p>On holdout it misses every lookup and returns all-zero, which gives the
+      downstream MWPM a broken hint and decodes strictly worse than plain MWPM
+      alone. That is the gap the independent verifier is built to catch.</p>
+    </section>"""
+
+
+def _pareto_card(verdict: str) -> str:
+    if verdict == "VERIFIED":
+        body = (
+            "If you see this banner the verifier is broken &mdash; the memorizer "
+            "has no fair-test signal and must never be admitted. Investigate "
+            "<code>autoqec/eval/independent_eval.py</code> before shipping."
+        )
+    elif verdict == "FAILED":
+        body = (
+            "This checkpoint is <strong>not</strong> admitted to "
+            "<code>pareto.json</code>. The corresponding experiment branch would be "
+            "tagged <code>status=rejected_by_verifier</code> in "
+            "<code>fork_graph.json</code> and kept around only as a negative "
+            "example for the Ideator."
+        )
+    else:
+        body = (
+            "This checkpoint is <strong>not</strong> admitted to "
+            "<code>pareto.json</code>. SUSPICIOUS means the verifier could not "
+            "confidently rule the cheat in or out &mdash; admission to the Pareto "
+            "archive requires a positive, CI-clear Δ_LER."
+        )
+    return f"""
+    <section class="card">
+      <h2>Phase 5 · Pareto consequence</h2>
+      <h3>What happens to this branch in the archive?</h3>
+      <p>{body}</p>
+    </section>"""
+
+
+def _hit_rate_card(phase2: dict) -> str:
+    seen = float(phase2["seen_hit_rate"]) * 100
+    fresh = float(phase2["fresh_train_hit_rate"]) * 100
+    hold = float(phase2["holdout_hit_rate"]) * 100
+    n = int(phase2.get("n_probes", 0))
+    return f"""
+    <section class="card">
+      <h2>Phase 2 · lookup-table hit rate</h2>
+      <h3>The cheat is bound to <em>specific shots</em>, not to the train seed range.</h3>
+      {_bar_row("memorized shots", seen, 100.0, "cheat", f"{seen:.1f}%")}
+      {_bar_row("fresh train-seed", fresh, 100.0, "train", f"{fresh:.1f}%")}
+      {_bar_row("holdout-seed", hold, 100.0, "plain", f"{hold:.1f}%")}
+      <p class="note">Fresh draws from the train seed range hit the table at roughly
+      the same rate as holdout draws &mdash; so the memorizer is not leaking seeds, it
+      is overfitting to exact syndromes. On a miss it outputs zero, which poisons the
+      downstream MWPM solver (over <strong>{n:,d}</strong> probes per bucket).</p>
+    </section>"""
+
+
+def _hit_rate_placeholder() -> str:
+    return """
+    <section class="card">
+      <h2>Phase 2 · lookup-table hit rate</h2>
+      <h3>not computed in this run</h3>
+      <p class="note">Run <code>bash demos/demo-4-reward-hacking/present.sh</code>
+      (the narrated mode) to populate <code>present_summary.json</code> with
+      memorized / fresh-train / holdout hit-rate probes for this card.</p>
+    </section>"""
+
+
+def _ler_card(report: dict, plain_ler: float) -> str:
+    pred = float(report["ler_holdout"])
+    lo, hi = report["ler_holdout_ci"]
+    delta = float(report["delta_ler_holdout"])
+    vmax = max(plain_ler, pred, float(hi), 0.01) * 1.15
+    return f"""
+    <section class="card">
+      <h2>Phase 3 · fair-test LER on holdout seeds</h2>
+      <h3>plain MWPM vs memorizer &mdash; lower is better</h3>
+      {_bar_row("plain MWPM", plain_ler, vmax, "plain", f"{plain_ler:.4f}")}
+      {_bar_row_with_ci(
+          "memorizer", pred, float(lo), float(hi), vmax, "cheat",
+          f"{pred:.4f}   95%CI [{float(lo):.3f}, {float(hi):.3f}]",
+      )}
+      <dl class="kv">
+        <dt>Δ_LER (holdout)</dt><dd>{delta:+.4f}</dd>
+        <dt>ler_shuffled (ablation)</dt><dd>{float(report.get("ler_shuffled", 0.0)):.4f}</dd>
+        <dt>paired bundle id</dt><dd>{html.escape(str(report.get("paired_eval_bundle_id", "—")))}</dd>
+      </dl>
+    </section>"""
+
+
+def _ler_placeholder() -> str:
+    return """
+    <section class="card">
+      <h2>Phase 3 · fair-test LER</h2>
+      <h3>plain_ler missing from notes</h3>
+      <p class="note">Expected a <code>plain_ler=</code> token in
+      <code>verification_report.json.notes</code>. Regenerate the report with
+      a newer verifier to render this card.</p>
+    </section>"""
+
+
+def _guards_card(guards: list[_Guard]) -> str:
+    rows = []
+    for g in guards:
+        tag = (
+            '<span class="tag pass">PASS</span>' if g.ok
+            else '<span class="tag fail">FAIL</span>'
+        )
+        rows.append(
+            f'<div class="guard">{tag}'
+            f'<div><div class="name">{html.escape(g.name)}</div>'
+            f'<div class="explain">{html.escape(g.explain)}</div></div></div>'
+        )
+    return f"""
+    <section class="card">
+      <h2>Phase 4 · three independent verifier guards</h2>
+      <h3>Any failing guard keeps the checkpoint off the Pareto front.</h3>
+      <div class="guards">{''.join(rows)}</div>
+    </section>"""
+
+
+def render_html(
+    report: dict, summary: dict | None, plain_ler: float | None, run_dir: Path,
+) -> str:
+    verdict = str(report.get("verdict", "UNKNOWN")).upper()
+    phrase = {
+        "FAILED": "cheat correctly rejected",
+        "SUSPICIOUS": "cheat kept off the Pareto front",
+        "VERIFIED": "THIS SHOULD NEVER HAPPEN &mdash; the verifier is broken",
+    }.get(verdict, "unknown verdict")
+
+    try:
+        run_dir_display = str(run_dir.relative_to(_REPO_ROOT))
+    except ValueError:
+        run_dir_display = str(run_dir)
+
+    hit_rate_html = (
+        _hit_rate_card(summary["phase2"])
+        if summary and isinstance(summary.get("phase2"), dict)
+        else _hit_rate_placeholder()
+    )
+    ler_html = _ler_card(report, plain_ler) if plain_ler is not None else _ler_placeholder()
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AutoQEC · Demo 4 · Reward-hacking detection</title>
+<style>{_CSS}</style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <h1>Reward-hacking detection</h1>
+    <div class="sub">AutoQEC &middot; Demo 4 &middot; run dir <code>{html.escape(run_dir_display)}</code></div>
+    <div class="banner {html.escape(verdict)}">
+      <span class="pill">verdict: {html.escape(verdict)}</span>
+      <span>{phrase}</span>
+    </div>
+  </header>
+
+  <div class="grid">
+    {_intro_card()}
+    {_pareto_card(verdict)}
+  </div>
+
+  <div class="grid full">
+    {hit_rate_html}
+    {ler_html}
+    {_guards_card(_derive_guards(report))}
+  </div>
+
+  <footer>
+    <div class="row"><code>holdout seeds: {html.escape(str(report.get("holdout_seeds_used") or []))}</code></div>
+    <div class="row">{html.escape(str(report.get("notes", "")))}</div>
+    <div class="row">
+      <a href="../verification_report.md">verification_report.md</a>
+      &nbsp;&middot;&nbsp;
+      <a href="../verification_report.json">verification_report.json</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>
+"""
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--run-dir",
+        default=str(_REPO_ROOT / "runs/demo-4/round_0"),
+        help="directory containing verification_report.json",
+    )
+    p.add_argument("--out", default=None, help="override output HTML path")
+    p.add_argument(
+        "--no-open", action="store_true",
+        help="skip browser auto-open (also honors AUTOQEC_NO_OPEN / CI env vars)",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    run_dir = Path(args.run_dir).resolve()
+    report = _load_required_report(run_dir)
+    summary = _load_optional_summary(run_dir)
+    plain_ler = _plain_ler_from_notes(str(report.get("notes", "")))
+
+    out_path = (
+        Path(args.out).resolve() if args.out else run_dir / "visualizations" / "index.html"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        render_html(report, summary, plain_ler, run_dir), encoding="utf-8",
+    )
+    print(f"  HTML written: {out_path}")
+
+    should_open = (
+        not args.no_open
+        and not os.environ.get("AUTOQEC_NO_OPEN")
+        and not os.environ.get("CI")
+    )
+    if should_open:
+        try:
+            webbrowser.open(out_path.as_uri())
+            print("  opened in default browser (set AUTOQEC_NO_OPEN=1 to skip)")
+        except Exception as exc:
+            print(f"  could not auto-open browser: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/demo-4-reward-hacking/run.sh
+++ b/demos/demo-4-reward-hacking/run.sh
@@ -11,7 +11,7 @@
 #   bash demos/demo-4-reward-hacking/run.sh --n-shots 20000 --n-seeds 10
 #
 # Env overrides:
-#   PYTHON=/path/to/python   override interpreter (defaults to `python`)
+#   PYTHON=/path/to/python   override interpreter (else picks project .venv)
 #   AUTOQEC_ENV_YAML=...     override env YAML (defaults to surface_d5_depol)
 set -euo pipefail
 
@@ -19,7 +19,9 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 cd "$REPO_ROOT"
 
-PY="${PYTHON:-python}"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/demos/_lib/python_bin.sh"
+PY="${PYTHON:-$(discover_demo_python "$REPO_ROOT")}"
 ENV_YAML="${AUTOQEC_ENV_YAML:-autoqec/envs/builtin/surface_d5_depol.yaml}"
 RUN_DIR="runs/demo-4/round_0"
 MODE="fast"
@@ -98,6 +100,9 @@ case "$VERDICT" in
     FAILED|SUSPICIOUS)
         echo ""
         echo "ok: reward-hacking checkpoint correctly rejected."
+        echo ""
+        echo "==> rendering HTML visualization"
+        "$PY" "$HERE/present_html.py" --run-dir "$RUN_DIR" || true
         exit 0
         ;;
     VERIFIED)

--- a/docs/agent-worktree.svg
+++ b/docs/agent-worktree.svg
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 820" font-family="ui-sans-serif, -apple-system, Segoe UI, sans-serif">
+  <defs>
+    <!-- Arrowheads -->
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+    <marker id="arrowMerge" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowFail" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#b91c1c"/>
+    </marker>
+    <marker id="arrowLight" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#94a3b8"/>
+    </marker>
+
+    <!-- Card gradient -->
+    <linearGradient id="cardBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f8fafc"/>
+    </linearGradient>
+    <linearGradient id="paretoGlow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fef3c7"/>
+      <stop offset="100%" stop-color="#fde68a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1240" height="820" fill="#f1f5f9"/>
+
+  <!-- Title bar -->
+  <text x="40" y="44" font-size="22" font-weight="700" fill="#0f172a">AutoQEC agent worktree model</text>
+  <text x="40" y="66" font-size="13" fill="#475569">run_id = <tspan font-family="ui-monospace, Menlo, monospace" fill="#0f172a">demo38-20260423-103750</tspan>  ·  one branch + one checkout per round  ·  subagent DAG runs inside the checkout</text>
+
+  <!-- ============================================================ -->
+  <!-- LEFT PANEL: repo + worktree filesystem                         -->
+  <!-- ============================================================ -->
+  <g transform="translate(40, 100)">
+    <rect x="0" y="0" width="480" height="680" rx="12" fill="url(#cardBg)" stroke="#cbd5e1"/>
+    <text x="20" y="28" font-size="14" font-weight="700" fill="#0f172a">Filesystem &amp; branches</text>
+    <text x="20" y="48" font-size="11" fill="#64748b">main repo (HEAD = main) plus one git-worktree checkout per experiment branch</text>
+
+    <!-- Main repo node -->
+    <g transform="translate(30, 80)">
+      <rect width="420" height="64" rx="8" fill="#0f172a"/>
+      <text x="18" y="26" font-size="13" font-weight="700" fill="#f8fafc">qec-ai-decoder/</text>
+      <text x="18" y="44" font-size="11" font-family="ui-monospace, Menlo, monospace" fill="#cbd5e1">HEAD → main  ·  f51cfcf</text>
+      <text x="18" y="58" font-size="11" fill="#94a3b8">orchestrator cwd · reads/writes runs/&lt;run_id&gt;/</text>
+    </g>
+
+    <!-- Connector lines from repo to each worktree -->
+    <path d="M 240 144 L 240 188" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
+    <path d="M 240 188 L 90 188"  stroke="#94a3b8" stroke-width="1.5" fill="none"/>
+    <path d="M 240 188 L 390 188" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
+    <text x="248" y="182" font-size="10" fill="#64748b" font-style="italic">git worktree add</text>
+
+    <!-- Worktree row 1: idea-a and idea-b -->
+    <g transform="translate(30, 200)">
+      <rect width="195" height="92" rx="8" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+      <rect x="0" y="0" width="195" height="20" rx="8" fill="#22c55e"/>
+      <rect x="0" y="10" width="195" height="10" fill="#22c55e"/>
+      <text x="10" y="14" font-size="10" font-weight="700" fill="#ffffff">VERIFIED · on Pareto</text>
+      <text x="10" y="38" font-size="11" font-family="ui-monospace, Menlo, monospace" fill="#0f172a">.worktrees/…/01-idea-a/</text>
+      <text x="10" y="54" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#334155">exp/…/01-idea-a</text>
+      <text x="10" y="72" font-size="10" fill="#64748b">round_1 · GNN 2-layer</text>
+      <text x="10" y="86" font-size="10" fill="#16a34a">Δ = +0.18 · 18M flops</text>
+    </g>
+    <g transform="translate(255, 200)">
+      <rect width="195" height="92" rx="8" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+      <rect x="0" y="0" width="195" height="20" rx="8" fill="#22c55e"/>
+      <rect x="0" y="10" width="195" height="10" fill="#22c55e"/>
+      <text x="10" y="14" font-size="10" font-weight="700" fill="#ffffff">VERIFIED · on Pareto</text>
+      <text x="10" y="38" font-size="11" font-family="ui-monospace, Menlo, monospace" fill="#0f172a">.worktrees/…/02-idea-b/</text>
+      <text x="10" y="54" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#334155">exp/…/02-idea-b</text>
+      <text x="10" y="72" font-size="10" fill="#64748b">round_2 · neural-BP 4 iter</text>
+      <text x="10" y="86" font-size="10" fill="#16a34a">Δ = +0.12 · 7M flops</text>
+    </g>
+
+    <!-- Worktree row 2: compose + conflict left/right -->
+    <g transform="translate(30, 308)">
+      <rect width="420" height="92" rx="8" fill="url(#paretoGlow)" stroke="#d97706" stroke-width="1.5"/>
+      <rect x="0" y="0" width="420" height="20" rx="8" fill="#d97706"/>
+      <rect x="0" y="10" width="420" height="10" fill="#d97706"/>
+      <text x="10" y="14" font-size="10" font-weight="700" fill="#ffffff">VERIFIED · compose merge (parents 01, 02)</text>
+      <text x="10" y="38" font-size="11" font-family="ui-monospace, Menlo, monospace" fill="#0f172a">.worktrees/…/03-compose-ab/</text>
+      <text x="10" y="54" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#334155">exp/…/03-compose-ab  (git merge 01-idea-a 02-idea-b)</text>
+      <text x="10" y="72" font-size="10" fill="#64748b">round_3 · GNN 2-layer + neural-BP post-pass</text>
+      <text x="10" y="86" font-size="10" fill="#b45309">Δ = +0.22 · 24M flops · dominates both parents</text>
+    </g>
+
+    <g transform="translate(30, 416)">
+      <rect width="195" height="92" rx="8" fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4,3" stroke-width="1.5"/>
+      <rect x="0" y="0" width="195" height="20" rx="8" fill="#64748b"/>
+      <rect x="0" y="10" width="195" height="10" fill="#64748b"/>
+      <text x="10" y="14" font-size="10" font-weight="700" fill="#ffffff">compose_conflict · no checkout</text>
+      <text x="10" y="38" font-size="11" font-family="ui-monospace, Menlo, monospace" fill="#0f172a">(no worktree — merge failed)</text>
+      <text x="10" y="54" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#334155">exp/…/90-conflict-left</text>
+      <text x="10" y="72" font-size="10" fill="#64748b">row written with branch=None</text>
+      <text x="10" y="86" font-size="10" fill="#64748b">commit_sha=None · status recorded</text>
+    </g>
+    <g transform="translate(255, 416)">
+      <rect width="195" height="92" rx="8" fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4,3" stroke-width="1.5"/>
+      <rect x="0" y="0" width="195" height="20" rx="8" fill="#64748b"/>
+      <rect x="0" y="10" width="195" height="10" fill="#64748b"/>
+      <text x="10" y="14" font-size="10" font-weight="700" fill="#ffffff">compose_conflict · no checkout</text>
+      <text x="10" y="38" font-size="11" font-family="ui-monospace, Menlo, monospace" fill="#0f172a">(no worktree — merge failed)</text>
+      <text x="10" y="54" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#334155">exp/…/91-conflict-right</text>
+      <text x="10" y="72" font-size="10" fill="#64748b">Ideator learns conflict signal</text>
+      <text x="10" y="86" font-size="10" fill="#64748b">via fork_graph on next round</text>
+    </g>
+
+    <!-- Extra connector stubs -->
+    <path d="M 128 144 L 128 200"  stroke="#94a3b8" stroke-width="1.5" fill="none"/>
+    <path d="M 352 144 L 352 200"  stroke="#94a3b8" stroke-width="1.5" fill="none"/>
+    <path d="M 240 144 L 240 308"  stroke="#94a3b8" stroke-width="1.5" fill="none" stroke-dasharray="2,2"/>
+    <path d="M 128 188 L 128 416"  stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="2,2" opacity="0.5"/>
+    <path d="M 352 188 L 352 416"  stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="2,2" opacity="0.5"/>
+
+    <!-- Footer: per-round artefacts -->
+    <g transform="translate(30, 532)">
+      <rect width="420" height="128" rx="8" fill="#0f172a"/>
+      <text x="14" y="22" font-size="12" font-weight="700" fill="#f8fafc">Written inside each worktree (round_&lt;N&gt;/ only):</text>
+      <text x="14" y="42" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#cbd5e1">  config.yaml      ← DSL dict</text>
+      <text x="14" y="58" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#cbd5e1">  checkpoint.pt    ← {class_name, state_dict, …}</text>
+      <text x="14" y="74" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#cbd5e1">  metrics.json     ← RoundMetrics (§2.2)</text>
+      <text x="14" y="90" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#cbd5e1">  train.log        ← &lt;step&gt;\t&lt;loss&gt;</text>
+      <text x="14" y="106" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#cbd5e1">  round_N_pointer.json ← provenance (read by reconcile)</text>
+      <text x="14" y="122" font-size="10" fill="#64748b" font-style="italic">orchestrator writes only at run root — never races the Runner</text>
+    </g>
+  </g>
+
+  <!-- ============================================================ -->
+  <!-- RIGHT PANEL: fork graph DAG                                    -->
+  <!-- ============================================================ -->
+  <g transform="translate(550, 100)">
+    <rect x="0" y="0" width="650" height="680" rx="12" fill="url(#cardBg)" stroke="#cbd5e1"/>
+    <text x="20" y="28" font-size="14" font-weight="700" fill="#0f172a">Fork graph · what the Ideator sees</text>
+    <text x="20" y="48" font-size="11" fill="#64748b">l3_for_ideator(run_id).fork_graph — nodes annotated with Δ_LER, FLOPs, Pareto flag</text>
+
+    <!-- Baseline -->
+    <g transform="translate(270, 80)">
+      <rect width="120" height="48" rx="8" fill="#1e293b"/>
+      <text x="60" y="20" font-size="12" font-weight="700" fill="#f8fafc" text-anchor="middle">baseline</text>
+      <text x="60" y="38" font-size="10" fill="#94a3b8" text-anchor="middle">MWPM · Δ = 0</text>
+    </g>
+
+    <!-- idea-a (round 1) -->
+    <g transform="translate(80, 180)">
+      <rect width="160" height="74" rx="8" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>
+      <text x="12" y="20" font-size="11" font-weight="700" fill="#166534">round_1 · 01-idea-a</text>
+      <text x="12" y="36" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#14532d">parent = baseline</text>
+      <text x="12" y="52" font-size="10" fill="#16a34a">Δ = +0.18 · 18M flops</text>
+      <circle cx="148" cy="14" r="6" fill="#facc15" stroke="#a16207"/>
+      <text x="148" y="18" font-size="9" font-weight="700" fill="#713f12" text-anchor="middle">P</text>
+      <text x="12" y="66" font-size="9" fill="#475569" font-style="italic">"shallow GNN on syndrome graph"</text>
+    </g>
+
+    <!-- idea-b (round 2) -->
+    <g transform="translate(420, 180)">
+      <rect width="160" height="74" rx="8" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>
+      <text x="12" y="20" font-size="11" font-weight="700" fill="#166534">round_2 · 02-idea-b</text>
+      <text x="12" y="36" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#14532d">parent = baseline</text>
+      <text x="12" y="52" font-size="10" fill="#16a34a">Δ = +0.12 · 7M flops</text>
+      <circle cx="148" cy="14" r="6" fill="#facc15" stroke="#a16207"/>
+      <text x="148" y="18" font-size="9" font-weight="700" fill="#713f12" text-anchor="middle">P</text>
+      <text x="12" y="66" font-size="9" fill="#475569" font-style="italic">"neural-BP, 4 message-pass iters"</text>
+    </g>
+
+    <!-- Edges baseline → round_1, round_2 -->
+    <path d="M 305 128 L 160 180" stroke="#334155" stroke-width="1.7" fill="none" marker-end="url(#arrow)"/>
+    <path d="M 355 128 L 500 180" stroke="#334155" stroke-width="1.7" fill="none" marker-end="url(#arrow)"/>
+
+    <!-- compose round 3 -->
+    <g transform="translate(240, 320)">
+      <rect width="180" height="88" rx="8" fill="url(#paretoGlow)" stroke="#d97706" stroke-width="2"/>
+      <text x="12" y="22" font-size="11" font-weight="700" fill="#92400e">round_3 · 03-compose-ab</text>
+      <text x="12" y="40" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#7c2d12">compose_mode = merge</text>
+      <text x="12" y="55" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#7c2d12">fork_from = [01, 02]</text>
+      <text x="12" y="72" font-size="10" font-weight="600" fill="#b45309">Δ = +0.22 · 24M flops</text>
+      <text x="12" y="84" font-size="9" fill="#7c2d12" font-style="italic">dominates both parents</text>
+      <circle cx="168" cy="14" r="6" fill="#facc15" stroke="#a16207"/>
+      <text x="168" y="18" font-size="9" font-weight="700" fill="#713f12" text-anchor="middle">P</text>
+    </g>
+
+    <!-- compose edges from round_1, round_2 -->
+    <path d="M 160 254 L 300 320" stroke="#2563eb" stroke-width="1.7" fill="none" marker-end="url(#arrowMerge)"/>
+    <path d="M 500 254 L 360 320" stroke="#2563eb" stroke-width="1.7" fill="none" marker-end="url(#arrowMerge)"/>
+    <text x="225" y="295" font-size="10" fill="#2563eb" font-style="italic">git merge</text>
+    <text x="420" y="295" font-size="10" fill="#2563eb" font-style="italic">git merge</text>
+
+    <!-- conflict rounds 90, 91 -->
+    <g transform="translate(40, 470)">
+      <rect width="200" height="80" rx="8" fill="#fef2f2" stroke="#b91c1c" stroke-dasharray="5,3" stroke-width="1.5"/>
+      <text x="12" y="22" font-size="11" font-weight="700" fill="#7f1d1d">round_90 · 90-conflict-left</text>
+      <text x="12" y="40" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#991b1b">status = compose_conflict</text>
+      <text x="12" y="56" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#991b1b">branch = None · sha = None</text>
+      <text x="12" y="72" font-size="9" fill="#991b1b" font-style="italic">merge refused — path overlap</text>
+    </g>
+    <g transform="translate(420, 470)">
+      <rect width="200" height="80" rx="8" fill="#fef2f2" stroke="#b91c1c" stroke-dasharray="5,3" stroke-width="1.5"/>
+      <text x="12" y="22" font-size="11" font-weight="700" fill="#7f1d1d">round_91 · 91-conflict-right</text>
+      <text x="12" y="40" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#991b1b">status = compose_conflict</text>
+      <text x="12" y="56" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="#991b1b">branch = None · sha = None</text>
+      <text x="12" y="72" font-size="9" fill="#991b1b" font-style="italic">row still appended to history</text>
+    </g>
+    <path d="M 330 408 L 140 470" stroke="#b91c1c" stroke-width="1.3" fill="none" stroke-dasharray="3,3" marker-end="url(#arrowFail)"/>
+    <path d="M 330 408 L 520 470" stroke="#b91c1c" stroke-width="1.3" fill="none" stroke-dasharray="3,3" marker-end="url(#arrowFail)"/>
+
+    <!-- subagent DAG (inside box) -->
+    <g transform="translate(20, 580)">
+      <rect width="610" height="82" rx="8" fill="#0f172a"/>
+      <text x="14" y="22" font-size="12" font-weight="700" fill="#f8fafc">What runs inside each worktree (per round)</text>
+
+      <!-- pipeline nodes -->
+      <g transform="translate(20, 40)">
+        <rect width="96" height="30" rx="6" fill="#7c3aed"/>
+        <text x="48" y="20" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">Ideator</text>
+      </g>
+      <g transform="translate(140, 40)">
+        <rect width="96" height="30" rx="6" fill="#0ea5e9"/>
+        <text x="48" y="20" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">Coder</text>
+      </g>
+      <g transform="translate(260, 40)">
+        <rect width="96" height="30" rx="6" fill="#f97316"/>
+        <text x="48" y="20" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">Runner</text>
+      </g>
+      <g transform="translate(380, 40)">
+        <rect width="96" height="30" rx="6" fill="#eab308"/>
+        <text x="48" y="20" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">Analyst</text>
+      </g>
+      <g transform="translate(500, 40)">
+        <rect width="96" height="30" rx="6" fill="#22c55e"/>
+        <text x="48" y="20" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">Verifier*</text>
+      </g>
+
+      <!-- pipeline arrows -->
+      <path d="M 116 55 L 140 55" stroke="#f8fafc" stroke-width="1.5" fill="none" marker-end="url(#arrowLight)"/>
+      <path d="M 236 55 L 260 55" stroke="#f8fafc" stroke-width="1.5" fill="none" marker-end="url(#arrowLight)"/>
+      <path d="M 356 55 L 380 55" stroke="#f8fafc" stroke-width="1.5" fill="none" marker-end="url(#arrowLight)"/>
+      <path d="M 476 55 L 500 55" stroke="#f8fafc" stroke-width="1.5" fill="none" marker-end="url(#arrowLight)" stroke-dasharray="3,2"/>
+
+      <text x="20" y="80" font-size="10" fill="#94a3b8">hypothesis → DSL → train+eval → verdict → (if candidate) holdout audit  ·  3-of-3 sign-off gates Pareto admit</text>
+    </g>
+  </g>
+
+  <!-- Legend footer -->
+  <g transform="translate(40, 790)">
+    <text x="0" y="0" font-size="11" fill="#475569">
+      <tspan font-weight="700" fill="#0f172a">Legend:</tspan>
+      <tspan dx="8" fill="#16a34a">■</tspan> VERIFIED &amp; Pareto
+      <tspan dx="18" fill="#d97706">■</tspan> compose merge (on Pareto)
+      <tspan dx="18" fill="#b91c1c">■</tspan> compose_conflict (no worktree)
+      <tspan dx="18" fill="#64748b">■</tspan> orphaned / reconciled
+      <tspan dx="18">·</tspan>
+      <tspan font-weight="700" fill="#a16207">P</tspan> = non-dominated on (Δ, flops, n_params)
+    </text>
+  </g>
+</svg>

--- a/docs/branding/logo-1-plaquette.svg
+++ b/docs/branding/logo-1-plaquette.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <title>AutoQEC — Auto-Ket |ψ⟩ (refined)</title>
+  <desc>A dominant 300° refresh-style auto-loop frames the Dirac ket |ψ⟩. The ψ inside is simultaneously the Greek letter and a 3-input → hub → output neural graph. Clean, minimal, strongly auto-coded.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a0f24"/>
+      <stop offset="1" stop-color="#121c3d"/>
+    </linearGradient>
+    <linearGradient id="loopGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0"   stop-color="#22d3ee"/>
+      <stop offset="0.55" stop-color="#60a5fa"/>
+      <stop offset="1"   stop-color="#e879f9"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="url(#bg)"/>
+
+  <!-- Motion trail: faint dashed continuation just past the loop's starting point,
+       suggesting the cycle keeps going -->
+  <path d="M 176 45 A 96 96 0 0 1 210 78"
+        fill="none" stroke="#22d3ee" stroke-width="3"
+        stroke-linecap="round" stroke-dasharray="1 9" opacity="0.55"/>
+
+  <!-- THE AUTO-LOOP (dominant element) -->
+  <path d="M 176 45 A 96 96 0 1 1 80 45"
+        fill="none" stroke="url(#loopGrad)" stroke-width="9" stroke-linecap="round"/>
+
+  <!-- Prominent arrowhead at the end of the loop (points clockwise-forward, upper-right) -->
+  <polygon points="80,45 72,59 64,45" fill="#e879f9"/>
+  <!-- Highlight dot just inside the arrowhead for a more finished look -->
+  <circle cx="72" cy="48.5" r="1.4" fill="#0a0f24" opacity="0.5"/>
+
+  <!-- AUTO wordmark sitting in the gap at top -->
+  <text x="128" y="40" text-anchor="middle"
+        font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI'"
+        font-size="12" font-weight="800" letter-spacing="4"
+        fill="#e879f9">AUTO</text>
+
+  <!-- Ket bracket | (left) -->
+  <line x1="82" y1="88" x2="82" y2="172"
+        stroke="#f0f9ff" stroke-width="5" stroke-linecap="round"/>
+
+  <!-- Ket bracket ⟩ (right angle) -->
+  <polyline points="170,88 190,130 170,172"
+            fill="none" stroke="#f0f9ff" stroke-width="5"
+            stroke-linejoin="round" stroke-linecap="round"/>
+
+  <!-- ψ strokes: central stem + two curved prongs (also = 3-in neural to hub → out) -->
+  <g fill="none" stroke="#67e8f9" stroke-width="2.8"
+     stroke-linecap="round" stroke-linejoin="round">
+    <!-- Central vertical stem of ψ -->
+    <line x1="128" y1="94" x2="128" y2="160"/>
+    <!-- Left prong -->
+    <path d="M 128 130 Q 110 116 108 100"/>
+    <!-- Right prong -->
+    <path d="M 128 130 Q 146 116 148 100"/>
+  </g>
+
+  <!-- Neural-network nodes on the ψ (3 inputs at top, 1 hub at junction, 1 output at bottom) -->
+  <!-- Inputs: soft cyan -->
+  <circle cx="108" cy="100" r="4.5" fill="#22d3ee"/>
+  <circle cx="128" cy="94"  r="4.5" fill="#22d3ee"/>
+  <circle cx="148" cy="100" r="4.5" fill="#22d3ee"/>
+  <!-- Hub: the decoder (magenta, larger, with subtle ring) -->
+  <circle cx="128" cy="130" r="8.5" fill="#e879f9"/>
+  <circle cx="128" cy="130" r="3"   fill="#fff"/>
+  <!-- Output: warm yellow -->
+  <circle cx="128" cy="160" r="5" fill="#fde68a"/>
+</svg>

--- a/docs/branding/logo-2-delta-lattice.svg
+++ b/docs/branding/logo-2-delta-lattice.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <title>AutoQEC — Neural Bloch</title>
+  <desc>A Bloch sphere whose state vector is drawn as a neural network path (nodes + edges) instead of a plain arrow; orbital auto-loop ring with |0⟩ / |1⟩ poles labelled — the AI decoder learning the qubit state across autonomous research rounds.</desc>
+
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a0f24"/>
+      <stop offset="1" stop-color="#0f1d42"/>
+    </linearGradient>
+    <radialGradient id="sphere" cx="0.35" cy="0.32" r="0.75">
+      <stop offset="0"   stop-color="#67e8f9"/>
+      <stop offset="0.55" stop-color="#22d3ee"/>
+      <stop offset="1"   stop-color="#0e7490"/>
+    </radialGradient>
+    <linearGradient id="autoRing" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#e879f9"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="url(#bg2)"/>
+
+  <!-- Auto-loop orbital ring (tilted ellipse = autonomous iteration) -->
+  <g transform="translate(128 132)">
+    <ellipse rx="104" ry="40" transform="rotate(-18)"
+             fill="none" stroke="url(#autoRing)" stroke-width="3"
+             stroke-dasharray="2 10" stroke-linecap="round"/>
+    <!-- Arrowhead on the ring to signal "auto-loop" -->
+    <g transform="rotate(-18) translate(104 0)">
+      <polygon points="0,-7 14,0 0,7" fill="#e879f9"/>
+    </g>
+  </g>
+
+  <!-- Bloch sphere -->
+  <g transform="translate(128 132)">
+    <circle r="58" fill="url(#sphere)" stroke="#f0f9ff" stroke-width="1.5" stroke-opacity="0.8"/>
+    <!-- Equator -->
+    <ellipse rx="58" ry="18" fill="none" stroke="#f0f9ff" stroke-width="1.2" stroke-opacity="0.55"/>
+    <!-- Meridian -->
+    <ellipse rx="18" ry="58" fill="none" stroke="#f0f9ff" stroke-width="1.2" stroke-opacity="0.4"/>
+    <!-- Polar axis -->
+    <line x1="0" y1="-58" x2="0" y2="58" stroke="#f0f9ff" stroke-width="1" stroke-opacity="0.35"/>
+  </g>
+
+  <!-- |0⟩ and |1⟩ pole labels -->
+  <g font-family="ui-sans-serif, system-ui, -apple-system" font-weight="600" fill="#f0f9ff">
+    <text x="128" y="66"  text-anchor="middle" font-size="14">|0&#10217;</text>
+    <text x="128" y="214" text-anchor="middle" font-size="14">|1&#10217;</text>
+  </g>
+
+  <!-- Neural state vector: edges from Bloch origin through hidden nodes to the state point -->
+  <g stroke="#fef3c7" stroke-width="2" fill="none" stroke-linecap="round">
+    <line x1="128" y1="132" x2="148" y2="118"/>
+    <line x1="148" y1="118" x2="166" y2="100"/>
+    <!-- dashed side-branches hinting at the network -->
+    <line x1="128" y1="132" x2="152" y2="132" stroke-opacity="0.5" stroke-dasharray="2 4"/>
+    <line x1="148" y1="118" x2="162" y2="130" stroke-opacity="0.5" stroke-dasharray="2 4"/>
+  </g>
+
+  <!-- Neural nodes along the vector -->
+  <g>
+    <!-- origin -->
+    <circle cx="128" cy="132" r="4" fill="#f0f9ff"/>
+    <!-- hidden nodes -->
+    <circle cx="148" cy="118" r="5.5" fill="#e879f9"/>
+    <circle cx="152" cy="132" r="3"   fill="#e879f9" opacity="0.7"/>
+    <circle cx="162" cy="130" r="3"   fill="#e879f9" opacity="0.7"/>
+    <!-- state tip -->
+    <circle cx="166" cy="100" r="6"   fill="#fef3c7" stroke="#fbbf24" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/docs/branding/logo-3-shielded-bloch.svg
+++ b/docs/branding/logo-3-shielded-bloch.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <title>AutoQEC — Decoder Loop</title>
+  <desc>A closed autonomous loop: a noisy qubit with an X error flows into a neural AI decoder, which emits a clean qubit; the arrow loops back to iterate. Quantum symbols (qubit circles with error/correction marks) + AI (central neural graph) + Auto (full closed loop).</desc>
+
+  <defs>
+    <linearGradient id="bg3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a0f24"/>
+      <stop offset="1" stop-color="#14224a"/>
+    </linearGradient>
+    <linearGradient id="loopGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="1" stop-color="#e879f9"/>
+    </linearGradient>
+    <radialGradient id="aiGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#e879f9" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#e879f9" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="url(#bg3)"/>
+
+  <!-- Auto-loop: a ring going noisy qubit → AI → clean qubit → back -->
+  <g fill="none" stroke="url(#loopGrad)" stroke-width="3.5" stroke-linecap="round">
+    <!-- top arc: clean → noisy (feedback / next syndrome frame) -->
+    <path d="M 182 70 A 78 78 0 0 0 74 70"/>
+    <!-- bottom arc: noisy → clean (through AI) -->
+    <path d="M 74 194 A 78 78 0 0 0 182 194"/>
+    <!-- arrowhead on the top arc (pointing left, feedback direction) -->
+    <path d="M 74 70 L 88 60 M 74 70 L 86 82"/>
+    <!-- arrowhead on the bottom arc (pointing right, forward flow) -->
+    <path d="M 182 194 L 168 204 M 182 194 L 170 182"/>
+  </g>
+
+  <!-- Noisy qubit (left) — circle with X error mark -->
+  <g transform="translate(60 132)">
+    <circle r="28" fill="#0a0f24" stroke="#22d3ee" stroke-width="2.5"/>
+    <!-- Bloch hint: equator -->
+    <ellipse rx="28" ry="9" fill="none" stroke="#22d3ee" stroke-width="1" stroke-opacity="0.55"/>
+    <!-- X error -->
+    <g stroke="#f87171" stroke-width="3.5" stroke-linecap="round">
+      <line x1="-10" y1="-10" x2="10" y2="10"/>
+      <line x1="10"  y1="-10" x2="-10" y2="10"/>
+    </g>
+    <text y="52" text-anchor="middle" font-size="11" font-family="ui-sans-serif,system-ui"
+          fill="#94a3b8" font-weight="600">syndrome</text>
+  </g>
+
+  <!-- Clean qubit (right) — circle with ket |ψ⟩ label -->
+  <g transform="translate(196 132)">
+    <circle r="28" fill="#0a0f24" stroke="#22d3ee" stroke-width="2.5"/>
+    <ellipse rx="28" ry="9" fill="none" stroke="#22d3ee" stroke-width="1" stroke-opacity="0.55"/>
+    <!-- State vector (clean) -->
+    <line x1="0" y1="0" x2="12" y2="-14" stroke="#fef3c7" stroke-width="2.2" stroke-linecap="round"/>
+    <circle cx="12" cy="-14" r="2.8" fill="#fef3c7"/>
+    <text y="52" text-anchor="middle" font-size="11" font-family="ui-sans-serif,system-ui"
+          fill="#94a3b8" font-weight="600">|&#968;&#10217;</text>
+  </g>
+
+  <!-- AI decoder (center) — neural graph -->
+  <g transform="translate(128 132)">
+    <circle r="36" fill="url(#aiGlow)"/>
+    <!-- 2-layer tiny network: 3 inputs → 2 hidden → 1 output, but horizontally compact -->
+    <g stroke="#e879f9" stroke-width="1.6" fill="none" stroke-opacity="0.9">
+      <!-- input-hidden -->
+      <line x1="-18" y1="-14" x2="0" y2="-8"/>
+      <line x1="-18" y1="0"   x2="0" y2="-8"/>
+      <line x1="-18" y1="14"  x2="0" y2="8"/>
+      <line x1="-18" y1="-14" x2="0" y2="8"/>
+      <line x1="-18" y1="14"  x2="0" y2="-8"/>
+      <line x1="-18" y1="0"   x2="0" y2="8"/>
+      <!-- hidden-output -->
+      <line x1="0" y1="-8" x2="18" y2="0"/>
+      <line x1="0" y1="8"  x2="18" y2="0"/>
+    </g>
+    <!-- nodes -->
+    <g fill="#0a0f24" stroke="#e879f9" stroke-width="2">
+      <circle cx="-18" cy="-14" r="3.5"/>
+      <circle cx="-18" cy="0"   r="3.5"/>
+      <circle cx="-18" cy="14"  r="3.5"/>
+      <circle cx="0"   cy="-8"  r="4.5"/>
+      <circle cx="0"   cy="8"   r="4.5"/>
+    </g>
+    <circle cx="18" cy="0" r="5.5" fill="#fef3c7"/>
+  </g>
+
+  <!-- Forward flow arrows: noisy → AI, AI → clean -->
+  <g stroke="#22d3ee" stroke-width="2" stroke-linecap="round" fill="none">
+    <line x1="92"  y1="132" x2="106" y2="132"/>
+    <line x1="150" y1="132" x2="164" y2="132"/>
+  </g>
+  <g fill="#22d3ee">
+    <polygon points="106,132 100,128 100,136"/>
+    <polygon points="164,132 158,128 158,136"/>
+  </g>
+
+  <!-- Top center label: AUTO -->
+  <text x="128" y="42" text-anchor="middle" font-size="10.5"
+        font-family="ui-sans-serif,system-ui" font-weight="700"
+        fill="#e879f9" letter-spacing="3">AUTO</text>
+</svg>

--- a/docs/branding/preview.html
+++ b/docs/branding/preview.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>AutoQEC — Logo Options</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin: 0; font-family: system-ui, sans-serif; background: #0a0f1f; color: #e5e7eb; }
+  h1 { text-align: center; padding: 24px 16px 0; font-weight: 600; letter-spacing: 0.02em; }
+  p.sub { text-align: center; color: #94a3b8; margin: 6px 0 32px; }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; padding: 0 32px 48px; }
+  .card { background: #111a32; border: 1px solid #1e293b; border-radius: 16px; padding: 20px; text-align: center; }
+  .card h2 { margin: 0 0 4px; font-size: 18px; }
+  .card .tag { color: #94a3b8; font-size: 13px; margin-bottom: 16px; }
+  .row { display: flex; justify-content: center; gap: 16px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
+  .sample-lg { width: 192px; height: 192px; }
+  .sample-md { width: 96px; height: 96px; }
+  .sample-sm { width: 32px; height: 32px; }
+  .sample-dl { background: #ffffff; border-radius: 12px; padding: 6px; }
+  .label { font-size: 11px; color: #64748b; margin-top: 4px; }
+  .rationale { color: #cbd5e1; font-size: 13px; line-height: 1.5; text-align: left; margin-top: 12px; }
+</style>
+</head>
+<body>
+  <h1>AutoQEC Logo Options</h1>
+  <p class="sub">Three concepts — same palette (deep quantum blue + cyan + magenta). Pick one.</p>
+  <div class="grid">
+    <div class="card">
+      <h2>Option 1 — Auto-Ket |ψ⟩</h2>
+      <div class="tag">Dirac ket + neural ψ + auto-loop</div>
+      <div class="row">
+        <div>
+          <img class="sample-lg" src="logo-1-plaquette.svg" alt=""/>
+          <div class="label">192px</div>
+        </div>
+      </div>
+      <div class="row">
+        <div><img class="sample-md" src="logo-1-plaquette.svg" alt=""/><div class="label">96px</div></div>
+        <div><img class="sample-sm" src="logo-1-plaquette.svg" alt=""/><div class="label">32px (favicon)</div></div>
+        <div class="sample-dl"><img class="sample-md" src="logo-1-plaquette.svg" alt=""/><div class="label" style="color:#475569">on white</div></div>
+      </div>
+      <p class="rationale">The auto-loop is now the dominant shape — a thick 300° refresh arrow with a chunky magenta arrowhead and a faint dashed "motion trail" just past the opening; "AUTO" sits in the gap at top. Inside, a minimal |ψ⟩: the ψ reads as both the Greek letter and a neural graph (3 cyan inputs → magenta hub decoder → yellow output). Noise removed.</p>
+    </div>
+
+    <div class="card">
+      <h2>Option 2 — Neural Bloch</h2>
+      <div class="tag">Bloch sphere + neural state vector + auto-orbit</div>
+      <div class="row">
+        <div>
+          <img class="sample-lg" src="logo-2-delta-lattice.svg" alt=""/>
+          <div class="label">192px</div>
+        </div>
+      </div>
+      <div class="row">
+        <div><img class="sample-md" src="logo-2-delta-lattice.svg" alt=""/><div class="label">96px</div></div>
+        <div><img class="sample-sm" src="logo-2-delta-lattice.svg" alt=""/><div class="label">32px (favicon)</div></div>
+        <div class="sample-dl"><img class="sample-md" src="logo-2-delta-lattice.svg" alt=""/><div class="label" style="color:#475569">on white</div></div>
+      </div>
+      <p class="rationale">Unambiguously quantum — Bloch sphere with labelled |0⟩/|1⟩ poles — but the state vector is rendered as a neural path (nodes + dashed side-branches), i.e. "the AI decoder's belief about the qubit state." A dashed tilted orbital ring with an arrowhead represents the auto-research loop running around the physics.</p>
+    </div>
+
+    <div class="card">
+      <h2>Option 3 — Decoder Loop</h2>
+      <div class="tag">syndrome → neural decoder → |ψ⟩, looped</div>
+      <div class="row">
+        <div>
+          <img class="sample-lg" src="logo-3-shielded-bloch.svg" alt=""/>
+          <div class="label">192px</div>
+        </div>
+      </div>
+      <div class="row">
+        <div><img class="sample-md" src="logo-3-shielded-bloch.svg" alt=""/><div class="label">96px</div></div>
+        <div><img class="sample-sm" src="logo-3-shielded-bloch.svg" alt=""/><div class="label">32px (favicon)</div></div>
+        <div class="sample-dl"><img class="sample-md" src="logo-3-shielded-bloch.svg" alt=""/><div class="label" style="color:#475569">on white</div></div>
+      </div>
+      <p class="rationale">Shows the entire AutoQEC pipeline: a left qubit with a red X error (the syndrome) → a central neural decoder → a right qubit with a clean state vector |ψ⟩. A closed cyan→magenta loop around them with two arrowheads makes the autonomous round cycle explicit. Most narrative; reads like a one-glance spec.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/status/2026-04-22-project-status.md
+++ b/docs/status/2026-04-22-project-status.md
@@ -1,0 +1,189 @@
+# AutoQEC Status — 2026-04-22 (Day-2 end)
+
+**Audience:** project admin / advisor.
+**Scope:** status of the AutoQEC research harness at the close of Day-2 of
+a 3-day sprint. Written for someone who wants the picture without reading
+every PR.
+
+---
+
+## 1. What AutoQEC is
+
+A self-driving research harness for **quantum error correction decoders**.
+It takes an environment (code × noise × compute constraints) and, through
+a multi-round loop of LLM sub-agents + a training runner, discovers neural
+*predecoders* that sit in front of a classical decoder (PyMatching /
+BP-OSD) and improve the logical error rate (Δ LER).
+
+One research round =
+`Ideator → Coder → Runner (train + eval) → Analyst → Verifier`.
+The Ideator proposes an architectural hypothesis, the Coder turns it into
+a validated DSL config, the Runner trains + evaluates, the Analyst
+summarises, the Verifier independently re-evaluates on a held-out seed
+range. Candidates that survive verification feed a Pareto front of
+(Δ LER, FLOPs, n_params).
+
+The MVP ships two reference environments:
+
+| Env | Code | Classical backend | Owner of env |
+|---|---|---|---|
+| `surface_d5_depol` | rotated d=5 surface code, circuit-level depolarising noise | MWPM (PyMatching) | Chen Jiahan |
+| `bb72_depol` | bivariate-bicycle [[72, 12, 6]] qLDPC | OSD (via ldpc) | Xie Jingu |
+
+Authoritative documents (frozen):
+
+- `docs/superpowers/specs/2026-04-20-autoqec-design.md` — v2.2 spec, source of truth.
+- `docs/contracts/interfaces.md` — 6 frozen interfaces (EnvSpec, RunnerConfig + RoundMetrics, VerifyReport, PredecoderModule I/O, subagent JSON shapes, skill CLI).
+- `docs/contracts/round_dir_layout.md` — who writes what inside `runs/<run_id>/round_<N>/`.
+
+---
+
+## 2. Development flow
+
+### 2.1 Spec → plan → TDD → review → merge
+
+Every substantive change goes through the same cycle:
+
+1. **Spec-level decision** lives in the frozen v2.2 design doc.
+2. **Plan** — a per-owner plan file (`docs/superpowers/plans/…`) breaks
+   the spec into bite-sized tasks (A1.4, A2.1, …). Each task is one
+   commit group.
+3. **Red/Green TDD** — failing unit test first, then implementation,
+   then green test. Contracts (pydantic schemas, JSON shapes) are
+   encoded as tests so drift fails CI rather than silently.
+4. **Cross-model review** — `/codex-review` ships the diff to GPT-5.4
+   via Codex MCP for an independent second opinion. Findings are
+   addressed in a follow-up commit on the same branch before merge.
+5. **Merge** — `feat/<owner>-<topic>` branch → PR → main. PRs are kept
+   small (one phase at a time) so review is tractable.
+
+### 2.2 What "frozen" actually means
+
+The Phase-0 contract freeze is not a doc promise — it is enforced in
+Python. `autoqec/envs/schema.py`, `autoqec/runner/schema.py`,
+`autoqec/eval/schema.py`, and `autoqec/agents/schemas.py` are pydantic
+models. `parse_response()` validates every subagent JSON payload against
+the per-role model before it can reach `history.jsonl`. Contract drift
+is a test failure, not a PR-review judgement call.
+
+### 2.3 Cross-model review = real signal, not theatre
+
+Both audits of Chen Jiahan's work produced actionable findings, not
+rubber stamps:
+
+- Day-1 Codex review caught 1 HIGH + 3 MED + 1 LOW + 1 open question
+  (most notable: the Coder prompt told the sub-agent to emit a bare
+  string for Tier-2 custom functions, but the runtime schema required
+  an object — every Tier-2 round would have crashed at compile time).
+- Day-2 Codex review caught 4 MED + 2 open questions (script
+  brittleness outside the repo root, an unguarded CUDA probe, a doc
+  that overclaimed its own test coverage).
+
+All findings were closed in follow-up commits before merge.
+
+---
+
+## 3. Collaboration shape
+
+### 3.1 Three owners, disjoint subtrees, frozen contracts between them
+
+| Owner | AI agent | Primary subtree | Secondary (delivery) |
+|---|---|---|---|
+| Chen Jiahan | Claude Code (Opus 4.7, 1M ctx) | `autoqec/envs/`, `autoqec/orchestration/`, `autoqec/agents/`, `.claude/agents/` | `/autoqec-run`, `/add-env`, Demo 1 |
+| Lin Tengxiang | Codex CLI (GPT-5.4) | `autoqec/decoders/`, `autoqec/runner/`, `cli/` | Demo 2 (bb72 templates), Makefile + CLI polish |
+| Xie Jingu | (TBD — currently using Codex) | `autoqec/eval/`, `circuits/bb72_*`, `autoqec/decoders/baselines/bposd*` | `/verify-decoder`, `/review-log`, `/diagnose-failure`, Demo 4, Demo 5 |
+
+The subtrees are disjoint, so merges rarely collide. When one owner
+needs a torch-free constant the other owns, the pattern is: extract
+constants to a lightweight module (`autoqec/decoders/custom_fn_rules.py`),
+have the heavy module re-export them — preserves the original API, lets
+the consumer import without pulling torch. No owner has unilaterally
+modified another owner's code.
+
+### 3.2 Execution principle — no one does only glue
+
+From the spec's §12.1: each owner has to touch real QEC artifacts as
+well as one delivery-facing surface. This prevents any one role
+becoming the "prompts and docs" person. Example: Chen Jiahan is the
+orchestration owner but personally ran the 1M-shot PyMatching baseline
+(`LER = 0.01394` at p = 5e-3, seed 42) that the whole team benchmarks Δ
+LER against.
+
+### 3.3 Synchronous coordination points
+
+- **Phase-0 sync** (before Day-1 coding) — walk through
+  `interfaces.md`, edit in the meeting, merge before anyone scaffolds.
+- **Pre-integration handshake** (Day-2) — the A2.1 e2e_handshake
+  script is the shared sandbox proving orchestration ↔ Runner works
+  with a hand-written Tier-1 config, *before* any LLM is wired in.
+- **Cross-review** — each owner reviews at least one other owner's QEC
+  artifact, not just prompts or docs.
+
+### 3.4 What's explicitly **not** in the collaboration model
+
+- No shared IDE sessions. Every owner drives their own agent.
+- No "one agent to rule them all". The agents above know their subtree
+  deeply and coordinate through the frozen contracts.
+- No informal interface changes. Any edit to `interfaces.md` or the
+  pydantic schemas requires 3-of-3 owner sign-off on the PR.
+
+---
+
+## 4. Harness system state (as of 2026-04-22, end of Day-2)
+
+### 4.1 Merged to `main`
+
+| PR | Content | Merge date |
+|---|---|---|
+| #2 | v2.2 spec + per-owner plans + Day-1 task briefs | 2026-04-21 |
+| #3 | Romanise team member names (Chinese → pinyin) for CI | 2026-04-21 |
+| #4 | Chen's Day-1 — benchmark, sub-agent prompts, orchestration skeleton, pydantic §2.5 | 2026-04-22 |
+| #5 | Chen's Day-2 — e2e_handshake, machine_state, run_single_round, round-dir layout | 2026-04-22 |
+| (earlier) | Lin's Runner slice + DSL compiler + GNN/Neural-BP templates | (before PR numbering) |
+
+### 4.2 Capabilities available today
+
+- **End-to-end baseline**: `python scripts/benchmark_surface_baseline.py` runs 1M-shot PyMatching on `surface_d5` and emits a JSON reference (`demos/demo-1-surface-d5/expected_output/baseline_benchmark.json`, LER = 0.01394 at p = 5e-3).
+- **No-LLM handshake**: `python scripts/e2e_handshake.py --round-dir <dir>` runs the full Runner on a hand-written Tier-1 GNN config. Proves the orchestration ↔ Runner interface end-to-end.
+- **Round planner**: `python scripts/run_single_round.py --env-yaml … --run-dir … --round-idx N` assembles the Ideator's L3 context (env + Pareto + history + machine-state + knowledge excerpts) and prints the prompt as JSON.
+- **Machine-state probe**: `machine_state(run_dir, total_wallclock_s_budget=…)` returns GPU free-VRAM + history-derived round timings + budget accounting. Gracefully returns `{}` on any CUDA/driver failure.
+- **Runner (Lin)**: `python -m cli.autoqec run <env.yaml> --rounds N --profile dev --no-llm` picks a random seed template from `autoqec/example_db/`, trains it, writes `metrics.json` + `checkpoint.pt` + `train.log`.
+- **Schemas enforced**: six frozen contracts live as pydantic models, validated on every round.
+
+### 4.3 Not yet built
+
+| Gap | Owner | Planned |
+|---|---|---|
+| Ideator/Coder/Analyst wired to real LLM calls through `Agent` tool | Chen | Day-3 |
+| `/autoqec-run` + `/add-env` SKILL.md | Chen | Day-3 |
+| Demo 1 README + run.sh + walkthrough (surface_d5 full demo) | Chen | Day-3 |
+| `independent_eval` + `/verify-decoder` | Xie | Day-3 |
+| Demo 2 (bb72 3-round dev-profile run) | Lin | Day-3 |
+| `/review-log` + `/diagnose-failure` | Xie | Day-3 |
+| Runner-side UTF-8 file opens + absolute-path `.resolve()` in `cli/autoqec.py::run` | Lin | [TODO-fill-in] flagged in `docs/contracts/round_dir_layout.md` |
+
+### 4.4 Test posture
+
+- **33 unit tests** on the CPU-only sweep for Chen's subtree (orchestration + agents + tools + scripts) — all green.
+- **1 integration test** for the full `e2e_handshake` training round — currently `@pytest.mark.integration`-gated; needs a torch-enabled CI runner to light up.
+- Lin's `tests/test_runner_smoke.py` is also `integration`-gated; runs the full training path on a minimal GNN.
+
+### 4.5 Risks the admin should know about
+
+- **No GPU integration test is being exercised yet.** The orchestration side is green in a torch-free env; the Runner side has an integration-marked smoke test but no one has flipped it on yet. Day-3's first deliverable is to run it.
+- **Day-3 scope is large.** Four skills + one full Demo + Verifier slice, across three owners. Buffer is thin.
+- **`cli/autoqec.py::run` passes a relative `round_dir`.** Every round's `metrics.json` then records `checkpoint_path` as relative, which breaks the Verifier's assumption it can be loaded from any cwd. One-line fix on Lin's side; flagged in the layout doc but not yet in.
+
+---
+
+## 5. Glossary for non-QEC readers
+
+- **QEC** — quantum error correction. The logical qubit is encoded across many physical ones; errors are detected through syndromes (indirect measurement).
+- **Decoder** — given a syndrome, guesses the most likely error and emits a correction.
+- **Predecoder** — a learned front-end that rewrites the syndrome or its priors before the classical decoder runs. Our research target.
+- **Surface code** — the canonical topological QEC code. `d=5` means distance 5 (error-correcting "thickness"). Industry-standard baseline.
+- **qLDPC / bb72** — quantum LDPC code, specifically bivariate-bicycle [[72, 12, 6]]. Harder than surface; tests that our harness isn't surface-specific.
+- **Stim** — the de-facto Clifford simulator for QEC experiments. We use it for circuit generation, sampling, and `DetectorErrorModel` extraction.
+- **PyMatching** — the standard MWPM decoder. Our surface-code baseline.
+- **LER** — logical error rate. `Δ LER` is the improvement a predecoder produces over the pure-classical baseline; it is the headline metric.
+- **Pareto** — the non-dominated front in (Δ LER, FLOPs, n_params). A "candidate" is a point on or near the front; "VERIFIED" means it survived an independent holdout evaluation.

--- a/tests/test_demo4_present.py
+++ b/tests/test_demo4_present.py
@@ -1,0 +1,116 @@
+"""Structural tests for the Demo 4 narrated presentation runner.
+
+These run without GPU/torch-heavy work by exercising just the pure-helper
+functions and then smoke-running the full script in -m "integration" mode
+when the user explicitly opts in via --run-integration. The structural
+checks are cheap: they assert the five phase headers, the argparse
+surface, and the skill wiring.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRESENT_PY = REPO_ROOT / "demos" / "demo-4-reward-hacking" / "present.py"
+PRESENT_SH = REPO_ROOT / "demos" / "demo-4-reward-hacking" / "present.sh"
+
+
+def test_present_py_exists_and_is_executable_from_python() -> None:
+    assert PRESENT_PY.is_file()
+    # --help must succeed and mention every required flag.
+    proc = subprocess.run(
+        [sys.executable, str(PRESENT_PY), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for flag in ("--env-yaml", "--run-dir", "--n-shots", "--n-seeds", "--n-probes", "--no-png"):
+        assert flag in proc.stdout, f"{flag} missing from --help"
+
+
+def test_present_py_declares_five_phases() -> None:
+    """The skill doc promises five labeled phases; enforce that the source
+    still actually prints PHASE 1..5 headers so the skill narration stays
+    in sync with the implementation."""
+    text = PRESENT_PY.read_text(encoding="utf-8")
+    for i in range(1, 6):
+        assert f"PHASE {i} " in text, f"PHASE {i} header missing in present.py"
+
+
+def test_present_sh_sources_shared_venv_helper() -> None:
+    """The launcher must source demos/_lib/python_bin.sh so it keeps
+    picking up the project .venv (same root-cause as the 2026-04-24 fix)."""
+    assert PRESENT_SH.is_file()
+    text = PRESENT_SH.read_text(encoding="utf-8")
+    assert "demos/_lib/python_bin.sh" in text
+    assert "discover_demo_python" in text
+    assert "present.py" in text
+
+
+def test_skill_demo_order_routes_demo4_through_present_sh() -> None:
+    """If someone reverts Demo 4 to run.sh in the skill doc, we lose the
+    narrated-mode walkthrough silently. Guard against that."""
+    skill = REPO_ROOT / ".claude" / "skills" / "demo-presenter" / "SKILL.md"
+    text = skill.read_text(encoding="utf-8")
+    assert "bash demos/demo-4-reward-hacking/present.sh" in text, (
+        "SKILL.md must advertise present.sh as Demo 4's live-walkthrough command"
+    )
+    # And the five-phase narration guidance must still be present.
+    for i in range(1, 6):
+        assert f"PHASE {i} " in text, f"SKILL.md lost PHASE {i} narration guidance"
+
+
+def test_live_present_demo_wires_demo4_to_present_sh() -> None:
+    """The live presenter must run present.sh (not run.sh) for Demo 4."""
+    live = REPO_ROOT / ".claude" / "skills" / "demo-presenter" / "scripts" / "live_present_demo.py"
+    text = live.read_text(encoding="utf-8")
+    assert "demos/demo-4-reward-hacking/present.sh" in text
+
+
+@pytest.mark.integration
+def test_present_py_emits_summary_json_and_ascii_sections(tmp_path: Path) -> None:
+    """End-to-end smoke: run present.py, assert summary JSON + the five
+    phase markers actually appeared in stdout. Gated on --run-integration
+    because it does real stim sampling and calls into independent_verify."""
+    run_dir = tmp_path / "demo-4"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(PRESENT_PY),
+            "--run-dir",
+            str(run_dir),
+            "--n-shots",
+            "1000",
+            "--n-seeds",
+            "3",
+            "--n-probes",
+            "500",
+            "--memorize-shots",
+            "2000",
+            "--no-png",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, f"present.py failed:\n{proc.stdout}\n{proc.stderr}"
+    for i in range(1, 6):
+        assert f"PHASE {i} " in proc.stdout, f"PHASE {i} header missing in stdout"
+
+    summary_path = run_dir / "present_summary.json"
+    assert summary_path.is_file(), "present_summary.json was not written"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["verdict"] in {"FAILED", "SUSPICIOUS"}, (
+        f"memorizer must be rejected; got {summary['verdict']}"
+    )
+    assert summary["phase2"]["seen_hit_rate"] > 0.9, (
+        "sanity: memorized-shots hit rate should be ~100%"
+    )
+    assert len(summary["phase4_guards"]) == 3

--- a/tests/test_demo4_present_html.py
+++ b/tests/test_demo4_present_html.py
@@ -1,0 +1,190 @@
+"""Tests for the Demo 4 HTML visualization generator.
+
+``present_html.py`` renders a self-contained HTML page from the verifier's
+JSON report so that ``run.sh`` / ``present.sh`` can open a browser window
+at the end of the demo. These tests exercise the pure-rendering path on a
+synthetic report fixture so they stay CPU-only and never touch the real
+``stim`` sampler.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRESENT_HTML = REPO_ROOT / "demos" / "demo-4-reward-hacking" / "present_html.py"
+RUN_SH = REPO_ROOT / "demos" / "demo-4-reward-hacking" / "run.sh"
+PRESENT_SH = REPO_ROOT / "demos" / "demo-4-reward-hacking" / "present.sh"
+
+
+@pytest.fixture
+def demo4_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "demo-4" / "round_0"
+    run_dir.mkdir(parents=True)
+    (run_dir / "verification_report.json").write_text(
+        json.dumps(
+            {
+                "verdict": "FAILED",
+                "ler_holdout": 0.2292,
+                "ler_holdout_ci": [0.2178, 0.2406],
+                "delta_ler_holdout": -0.2166,
+                "ler_shuffled": 0.2292,
+                "ablation_sanity_ok": True,
+                "holdout_seeds_used": [9000, 9001, 9002],
+                "seed_leakage_check_ok": True,
+                "notes": "n_shots=5000, plain_ler=0.0126, pred_ler=0.2292, shuffled_ler=0.2292",
+                "paired_eval_bundle_id": "4d89644f-f0e7-5442-965f-4ffc11047fbe",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "AUTOQEC_NO_OPEN": "1"}
+    return subprocess.run(
+        [sys.executable, str(PRESENT_HTML), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
+def test_present_html_exists_and_advertises_flags() -> None:
+    assert PRESENT_HTML.is_file()
+    proc = _run("--help")
+    assert proc.returncode == 0, proc.stderr
+    for flag in ("--run-dir", "--out", "--no-open"):
+        assert flag in proc.stdout, f"{flag} missing from --help"
+
+
+def test_present_html_writes_index_with_verdict_banner(demo4_run_dir: Path) -> None:
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0, f"stderr={proc.stderr}\nstdout={proc.stdout}"
+    out = demo4_run_dir / "visualizations" / "index.html"
+    assert out.is_file()
+    body = out.read_text(encoding="utf-8")
+    assert "<!doctype html>" in body.lower()
+    assert "verdict: FAILED" in body
+    assert "cheat correctly rejected" in body
+    for guard in ("seed-leakage hygiene", "paired bootstrap CI", "ablation sanity"):
+        assert guard in body, f"{guard} card missing from HTML"
+
+
+def test_present_html_renders_ler_numbers(demo4_run_dir: Path) -> None:
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0
+    body = (demo4_run_dir / "visualizations" / "index.html").read_text(encoding="utf-8")
+    assert "0.0126" in body, "plain MWPM LER (from notes) missing"
+    assert "0.2292" in body, "memorizer holdout LER missing"
+    assert "-0.2166" in body, "Δ_LER missing"
+    assert "4d89644f-f0e7-5442-965f-4ffc11047fbe" in body, "paired eval bundle id missing"
+
+
+def test_present_html_falls_back_when_summary_absent(demo4_run_dir: Path) -> None:
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0
+    body = (demo4_run_dir / "visualizations" / "index.html").read_text(encoding="utf-8")
+    # Phase 2 hit-rate card should show the "not computed" placeholder.
+    assert "not computed" in body
+    assert "present.sh" in body, "placeholder must point users at the narrated mode"
+
+
+def test_present_html_uses_summary_when_available(demo4_run_dir: Path) -> None:
+    (demo4_run_dir / "present_summary.json").write_text(
+        json.dumps(
+            {
+                "verdict": "FAILED",
+                "phase2": {
+                    "seen_hit_rate": 1.0,
+                    "fresh_train_hit_rate": 0.002,
+                    "holdout_hit_rate": 0.0015,
+                    "n_probes": 2000,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0
+    body = (demo4_run_dir / "visualizations" / "index.html").read_text(encoding="utf-8")
+    assert "100.0%" in body, "memorized-shots hit rate missing"
+    assert "0.2%" in body, "fresh-train hit rate missing"
+    assert "not computed" not in body, "placeholder still shown despite present_summary.json"
+
+
+def test_present_html_handles_suspicious_verdict(demo4_run_dir: Path) -> None:
+    report_path = demo4_run_dir / "verification_report.json"
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    data["verdict"] = "SUSPICIOUS"
+    data["delta_ler_holdout"] = 0.0001  # inside CI
+    report_path.write_text(json.dumps(data), encoding="utf-8")
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0
+    body = (demo4_run_dir / "visualizations" / "index.html").read_text(encoding="utf-8")
+    assert "verdict: SUSPICIOUS" in body
+    assert "kept off the Pareto front" in body
+
+
+def test_present_html_no_broken_template_placeholders(demo4_run_dir: Path) -> None:
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0
+    body = (demo4_run_dir / "visualizations" / "index.html").read_text(encoding="utf-8")
+    # Catch f-string leftovers / unformatted placeholders.
+    for bad in ("{report", "{html.escape", "{summary", "{float(", "{verdict}"):
+        assert bad not in body, f"unreplaced template fragment: {bad}"
+
+
+def test_run_sh_invokes_html_generator() -> None:
+    """run.sh must call present_html.py after a successful verdict so the
+    user gets an HTML visualization at the end of the demo."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    assert "present_html.py" in text
+    assert "rendering HTML visualization" in text
+
+
+def test_present_sh_invokes_html_generator() -> None:
+    """present.sh (narrated mode) must also generate the HTML, which picks
+    up the richer present_summary.json hit-rate data."""
+    text = PRESENT_SH.read_text(encoding="utf-8")
+    assert "present_html.py" in text
+    assert "rendering HTML visualization" in text
+    # Must still propagate present.py's exit code.
+    assert "exit $rc" in text or "exit ${rc}" in text
+
+
+def test_failed_verdict_uses_green_banner(demo4_run_dir: Path) -> None:
+    """For demo-4 the 'good' outcome is that the cheat is rejected. A red
+    FAILED banner would mislead users into thinking the verifier broke, so
+    the banner color must track DEMO OUTCOME: FAILED→green, VERIFIED→red."""
+    proc = _run("--run-dir", str(demo4_run_dir), "--no-open")
+    assert proc.returncode == 0
+    body = (demo4_run_dir / "visualizations" / "index.html").read_text(encoding="utf-8")
+    # Green (rgba(34,197,94,…)) must be wired to .banner.FAILED, not .VERIFIED.
+    assert ".banner.FAILED{background:rgba(34,197,94" in body, (
+        "FAILED banner must use the green --ok color (cheat rejected = good)"
+    )
+    assert ".banner.VERIFIED{background:rgba(185,28,28" in body, (
+        "VERIFIED banner must use the red --bad color (cheat admitted = broken)"
+    )
+
+
+def test_present_html_respects_autoqec_no_open(demo4_run_dir: Path) -> None:
+    """When AUTOQEC_NO_OPEN=1 is set, the generator must not print the
+    'opened in default browser' line (used as a proxy for the real call)."""
+    env = {**os.environ, "AUTOQEC_NO_OPEN": "1"}
+    proc = subprocess.run(
+        [sys.executable, str(PRESENT_HTML), "--run-dir", str(demo4_run_dir)],
+        check=False, capture_output=True, text=True, cwd=REPO_ROOT, env=env,
+    )
+    assert proc.returncode == 0
+    assert "opened in default browser" not in proc.stdout

--- a/tests/test_demo_presenter_speak_demo.py
+++ b/tests/test_demo_presenter_speak_demo.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(".claude/skills/demo-presenter/scripts/speak_demo.py")
+LIVE_SCRIPT_PATH = Path(".claude/skills/demo-presenter/scripts/live_present_demo.py")
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("speak_demo", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_live_script():
+    spec = importlib.util.spec_from_file_location("live_present_demo", LIVE_SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_chunk_text_splits_long_script_without_losing_words():
+    module = load_script()
+    text = "Intro sentence. " + ("AutoQEC proves auditable demo evidence. " * 20)
+
+    chunks = module.chunk_text(text, max_chars=120)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 120 for chunk in chunks)
+    assert " ".join(chunks).replace("  ", " ") == text.strip()
+
+
+def test_build_parser_defaults_to_presentation_voice_and_mp3():
+    module = load_script()
+
+    args = module.build_parser().parse_args(["demo_script.txt"])
+
+    assert args.input == Path("demo_script.txt")
+    assert args.output == Path("demo_script.mp3")
+    assert args.model == "gpt-4o-mini-tts"
+    assert args.voice == "coral"
+    assert "technical presentation" in args.instructions
+
+
+def test_resolve_base_url_prefers_cli_over_environment(monkeypatch):
+    module = load_script()
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://env.example/v1")
+
+    assert module.resolve_base_url("https://cli.example/v1") == "https://cli.example/v1"
+    assert module.resolve_base_url(None) == "https://env.example/v1"
+
+
+def test_live_plan_marks_worktree_demo_pr_only_by_default():
+    module = load_live_script()
+
+    steps = module.build_demo_steps(include_pr_worktree=False)
+
+    assert [step.demo_id for step in steps] == ["1", "2", "3", "4", "5"]
+    worktree_step = next(step for step in steps if step.demo_id == "3")
+    assert worktree_step.command is None
+    assert "PR-only" in worktree_step.status
+
+
+def test_live_dry_run_writes_manifest_without_running_commands(tmp_path, monkeypatch):
+    module = load_live_script()
+    step = module.DemoStep(
+        demo_id="x",
+        name="Synthetic demo",
+        status="test",
+        command=["definitely-not-run"],
+        pre_narration="before",
+        post_success="success",
+        post_failure="failure",
+        artifacts=["artifact.json"],
+    )
+    monkeypatch.setattr(
+        module,
+        "run_command",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("command ran")),
+    )
+
+    report = module.execute_demo_steps(
+        steps=[step],
+        output_dir=tmp_path,
+        dry_run=True,
+        audio=False,
+        playback=False,
+        base_url=None,
+        model="gpt-4o-mini-tts",
+        voice="coral",
+        instructions="test voice",
+    )
+
+    assert report["steps"][0]["result"] == "dry-run"
+    assert (tmp_path / "manifest.json").exists()
+
+
+def _install_overlap_fakes(module, monkeypatch, events: list[str]):
+    def fake_synthesize(*, text, output_path, audio, **_kwargs):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if audio:
+            output_path.write_bytes(b"fake-audio")
+            return output_path
+        txt = output_path.with_suffix(".txt")
+        txt.write_text(text)
+        return txt
+
+    class FakeAudioProc:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def wait(self, timeout: float | None = None) -> int:
+            events.append(f"wait:{self.label}")
+            return 0
+
+    def fake_start_playback(path):
+        events.append(f"start:{path.name}")
+        return FakeAudioProc(path.name)
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = "ok"
+
+    def fake_run_command(command, log_path):
+        events.append(f"run:{command[-1]}")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("ok")
+        return FakeCompleted()
+
+    def fake_play_audio(path):
+        events.append(f"play:{path.name}")
+
+    monkeypatch.setattr(module, "synthesize_narration", fake_synthesize)
+    monkeypatch.setattr(module, "start_playback", fake_start_playback)
+    monkeypatch.setattr(module, "run_command", fake_run_command)
+    monkeypatch.setattr(module, "play_audio", fake_play_audio)
+
+
+def test_live_overlaps_pre_narration_with_demo_command(tmp_path, monkeypatch):
+    module = load_live_script()
+    events: list[str] = []
+    _install_overlap_fakes(module, monkeypatch, events)
+
+    step = module.DemoStep(
+        demo_id="x",
+        name="overlap test",
+        status="test",
+        command=["echo", "overlap-marker"],
+        pre_narration="pre",
+        post_success="ok",
+        post_failure="nope",
+        artifacts=[],
+    )
+
+    module.execute_demo_steps(
+        steps=[step],
+        output_dir=tmp_path,
+        dry_run=False,
+        audio=True,
+        playback=True,
+        base_url=None,
+        model="m",
+        voice="v",
+        instructions="i",
+    )
+
+    start_idx = events.index("start:demo-x-before.mp3")
+    run_idx = events.index("run:overlap-marker")
+    wait_idx = events.index("wait:demo-x-before.mp3")
+    assert start_idx < run_idx < wait_idx, events
+    assert events[wait_idx + 1] == "play:demo-x-after.mp3", events
+
+
+def test_live_dry_run_plays_pre_narration_without_overlap(tmp_path, monkeypatch):
+    module = load_live_script()
+    events: list[str] = []
+    _install_overlap_fakes(module, monkeypatch, events)
+
+    def fail_run_command(*_args, **_kwargs):
+        raise AssertionError("dry-run must not execute commands")
+
+    monkeypatch.setattr(module, "run_command", fail_run_command)
+
+    step = module.DemoStep(
+        demo_id="y",
+        name="dry overlap",
+        status="test",
+        command=["should-not-run"],
+        pre_narration="pre",
+        post_success="ok",
+        post_failure="nope",
+        artifacts=[],
+    )
+
+    module.execute_demo_steps(
+        steps=[step],
+        output_dir=tmp_path,
+        dry_run=True,
+        audio=True,
+        playback=True,
+        base_url=None,
+        model="m",
+        voice="v",
+        instructions="i",
+    )
+
+    assert "start:demo-y-before.mp3" in events
+    assert "wait:demo-y-before.mp3" in events
+    assert not any(evt.startswith("run:") for evt in events)
+
+
+def test_live_start_playback_returns_none_when_no_async_player(tmp_path, monkeypatch):
+    module = load_live_script()
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+    audio_file = tmp_path / "clip.mp3"
+    audio_file.write_bytes(b"fake")
+
+    assert module.start_playback(audio_file) is None
+
+
+def test_live_start_playback_ignores_text_file(tmp_path):
+    module = load_live_script()
+    text_file = tmp_path / "narration.txt"
+    text_file.write_text("hello")
+
+    assert module.start_playback(text_file) is None

--- a/tests/test_demo_python_bin.py
+++ b/tests/test_demo_python_bin.py
@@ -1,0 +1,98 @@
+"""Tests for demos/_lib/python_bin.sh.
+
+The helper resolves the project venv python so Demo 1 and Demo 4 launchers
+pick up the shared ``.venv`` even when the bash shell's ``PATH`` points at
+a system Python that does not have ``torch`` installed (which is what
+broke the advisor walkthrough on 2026-04-24).
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "demos" / "_lib" / "python_bin.sh"
+
+
+def _requires_bash() -> None:
+    if shutil.which("bash") is None:
+        pytest.skip("bash not available on this host")
+
+
+def _run_discover(start_dir: Path, env: dict[str, str] | None = None) -> str:
+    _requires_bash()
+    bash_bin = shutil.which("bash")
+    assert bash_bin is not None
+    cmd = [
+        bash_bin,
+        "-c",
+        f'set -euo pipefail; source "{HELPER.as_posix()}"; discover_demo_python "{start_dir.as_posix()}"',
+    ]
+    proc = subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return proc.stdout.strip()
+
+
+def test_helper_file_exists() -> None:
+    assert HELPER.is_file(), "demos/_lib/python_bin.sh is required by Demo 1 + Demo 4"
+
+
+def test_prefers_windows_venv_from_worktree_subdir(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = repo / ".worktrees" / "exp-1"
+    venv = repo / ".venv" / "Scripts" / "python.exe"
+    venv.parent.mkdir(parents=True)
+    venv.write_text("", encoding="utf-8")
+    venv.chmod(0o755)
+    worktree.mkdir(parents=True)
+
+    assert _run_discover(worktree) == str(venv.as_posix())
+
+
+def test_prefers_unix_venv_when_no_windows_layout(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    venv = repo / ".venv" / "bin" / "python"
+    venv.parent.mkdir(parents=True)
+    venv.write_text("", encoding="utf-8")
+    venv.chmod(0o755)
+    nested = repo / "demos" / "demo-X"
+    nested.mkdir(parents=True)
+
+    assert _run_discover(nested) == str(venv.as_posix())
+
+
+def test_falls_back_when_no_venv_found(tmp_path: Path) -> None:
+    # Unrelated tmp subdir with no .venv anywhere above it. On every host
+    # we run tests on, either python3 or python resolves via PATH — we just
+    # check the helper drops through to that branch rather than exploding.
+    target = tmp_path / "elsewhere"
+    target.mkdir()
+    result = _run_discover(target)
+    assert result in {"python3", "python"}, f"unexpected fallback: {result!r}"
+
+
+def test_demo1_launcher_uses_helper() -> None:
+    """Demo 1's run_quick.sh must source the shared helper so it picks up
+    the project venv, not the system python that broke the 2026-04-24 walkthrough."""
+    launcher = REPO_ROOT / "demos" / "demo-1-surface-d5" / "run_quick.sh"
+    assert launcher.is_file()
+    text = launcher.read_text(encoding="utf-8")
+    assert "demos/_lib/python_bin.sh" in text
+    assert "discover_demo_python" in text
+
+
+def test_demo4_launcher_uses_helper() -> None:
+    launcher = REPO_ROOT / "demos" / "demo-4-reward-hacking" / "run.sh"
+    assert launcher.is_file()
+    text = launcher.read_text(encoding="utf-8")
+    assert "demos/_lib/python_bin.sh" in text
+    assert "discover_demo_python" in text


### PR DESCRIPTION
## Summary

Bundles seven post-orchestrator-trace follow-on commits into one PR. Supersedes and closes #76.

| # | Commit | What it adds |
|---|---|---|
| 1 | `docs(claude): pin PR-review output to GitHub comments` | New CLAUDE.md section: review skills must `gh pr comment`, never leave local markdown. |
| 2 | `feat(demo): add /demo-presenter skill and Demo 4 narrated walkthrough` | New `/demo-presenter` slash-skill (SKILL.md + scripts/live_present_demo.py + scripts/speak_demo.py + agents/openai.yaml), shared `demos/_lib/python_bin.sh` venv discovery, and the first concrete walkthrough on Demo 4 (`present.py`/`present.sh`/`present_html.py`) with five labeled phases, ASCII bar charts, and a matplotlib scoreboard PNG. CI semantics unchanged: exits 0 iff the cheat is rejected. Four new test files. |
| 3 | `docs(readme): add agent DAG and branch-tree visualizations` | Architecture-at-a-glance refactor: 5-box agent DAG (Ideator → Coder → Runner → Analyst → Verifier) + branch-tree ASCII for the worktree-as-Pareto model from §15, with star/diamond/circle legend for on-Pareto / merge-refused / orphan-recovered. |
| 4 | `docs(branding): add SVG logos, preview page, and agent-worktree diagram` | Three logo candidates + preview HTML + vector agent-worktree diagram for slides. |
| 5 | `docs(status): add 2026-04-22 project status snapshot` | First entry under `docs/status/` capturing F1–F6 + demo + skill state for hackathon reference. |
| 6 | `ci: add codecov.yml configuration` | Codecov informational-only thresholds, comment layout, and `tests/scripts/demos/docs/knowledge/__init__.py` ignore list. |
| 7 | `docs(readme): reflect merged demo-3, demo-6, and /review-framework skill` | Originally PR #76. Adds Demo 3 / Demo 6 to the one-prompt review block and tables; adds `/review-framework` to the skills table; bumps counts. |

Total: 23 files, +3615 / −21.

## Why one PR

Originally I opened these as #74 (`/review-framework` skill), #75 (orchestrator-trace branch), and #76 (README current-state). #74 and #75 are merged; the remaining six follow-on commits and #76's README refresh are all light, low-risk docs/skill/CI work that's easier to review and merge as a single bundle than as four mini-PRs.

## One small conflict resolution

Cherry-pick of #76's commit conflicted with the architecture-section refactor (commit 3) on a single narrative line in the Skills section. Took the #76 version (more current — mentions `/review-framework`).

## Test plan

- [ ] `pytest tests/ -m "not integration" -q` stays green (the four new test files exercise the new demo-presenter + Demo 4 narration scripts).
- [ ] `bash demos/demo-4-reward-hacking/present.sh` produces phase-labeled output and a `runs/demo-4/round_0/visualizations/scoreboard.png`; `run.sh` still exits 0 for the rejected cheat.
- [ ] Render README on github.com — agent DAG, branch-tree, and updated Demos / Skills tables look right.
- [ ] Codecov report on the PR uses the new layout / ignores tests/, scripts/, demos/, docs/, knowledge/.