### PR TITLE
feat: add GPU positive AI loop demo

### DIFF
--- a/autoqec/agents/cli_backend.py
+++ b/autoqec/agents/cli_backend.py
@@ -15,6 +15,10 @@ import re
 import subprocess
 from typing import Literal
 
+from pydantic import ValidationError
+
+from autoqec.agents.schemas import ROLE_SCHEMAS
+
 Role = Literal["ideator", "coder", "analyst"]
 
 
@@ -56,6 +60,33 @@ def _parse_fenced_json(stdout: str) -> dict:
         raise InvalidSubagentResponseError(f"malformed json: {exc}") from exc
 
 
+def _normalize_payload(role: Role, payload: dict) -> dict:
+    normalized = dict(payload)
+    if role == "analyst":
+        if "summary_1line" not in normalized and "summary" in normalized:
+            normalized["summary_1line"] = normalized["summary"]
+        normalized.pop("summary", None)
+
+        if "verdict" not in normalized and "classification" in normalized:
+            normalized["verdict"] = normalized["classification"]
+        normalized.pop("classification", None)
+
+        if "next_hypothesis_seed" not in normalized:
+            normalized["next_hypothesis_seed"] = "continue from analyst summary"
+    return normalized
+
+
+def _parse_validated_payload(role: Role, stdout: str) -> dict:
+    payload = _normalize_payload(role, _parse_fenced_json(stdout))
+    schema = ROLE_SCHEMAS[role]
+    try:
+        return schema.model_validate(payload).model_dump()
+    except ValidationError as exc:
+        raise InvalidSubagentResponseError(
+            f"Invalid {role} response payload: {exc}"
+        ) from exc
+
+
 def invoke_subagent(role: Role, prompt: str, timeout: float = 300.0) -> dict:
     argv = _build_cli_argv(role)
     child_env = os.environ.copy()
@@ -73,6 +104,6 @@ def invoke_subagent(role: Role, prompt: str, timeout: float = 300.0) -> dict:
     )
     if result.returncode != 0:
         raise InvalidSubagentResponseError(
-            f"{argv[0]} exit {result.returncode}: {result.stderr[:200]}"
+            f"{argv[0]} exit {result.returncode}: {result.stderr[:1200]}"
         )
-    return _parse_fenced_json(result.stdout)
+    return _parse_validated_payload(role, result.stdout)

--- a/autoqec/agents/schemas.py
+++ b/autoqec/agents/schemas.py
@@ -52,6 +52,8 @@ class AnalystResponse(BaseModel):
     summary_1line: str
     verdict: Literal["candidate", "ignore"]
     next_hypothesis_seed: str
+    branch: Optional[str] = None
+    commit_sha: Optional[str] = None
 
 
 ROLE_SCHEMAS: dict[str, type[BaseModel]] = {

--- a/autoqec/decoders/modules/gnn.py
+++ b/autoqec/decoders/modules/gnn.py
@@ -48,6 +48,15 @@ def _aggregate(agg: str, messages: Tensor, index: Tensor, n_targets: int) -> Ten
     raise ValueError(f"unsupported aggregation: {agg}")
 
 
+def _zero_init_last_linear(module: nn.Module) -> None:
+    for child in reversed(list(module.modules())):
+        if isinstance(child, nn.Linear):
+            nn.init.zeros_(child.weight)
+            if child.bias is not None:
+                nn.init.zeros_(child.bias)
+            return
+
+
 class BipartiteGNN(PredecoderBase):
     def __init__(
         self,
@@ -76,6 +85,7 @@ class BipartiteGNN(PredecoderBase):
         self.norm_name = normalization
         if output_mode == "soft_priors":
             self.head = make_head(head_type, hidden_dim, 1)
+            _zero_init_last_linear(self.head)
         else:
             self.head = make_head(head_type, hidden_dim, 1)
 
@@ -123,6 +133,14 @@ class BipartiteGNN(PredecoderBase):
 
         if self.output_mode == "soft_priors":
             logits = self.head(h_v).squeeze(-1)
+            prior_p = ctx.get("prior_p")
+            if prior_p is not None:
+                prior = torch.as_tensor(
+                    prior_p,
+                    dtype=logits.dtype,
+                    device=logits.device,
+                ).clamp(1e-6, 1 - 1e-6)
+                logits = logits + torch.logit(prior).unsqueeze(0)
             return torch.sigmoid(logits)
 
         # hard_flip: return soft sigmoid probabilities so gradients flow
@@ -131,4 +149,3 @@ class BipartiteGNN(PredecoderBase):
         # autoqec.decoders.backend_adapter.decode_with_predecoder).
         logits = self.head(h_c).squeeze(-1)
         return torch.sigmoid(logits)
-

--- a/autoqec/orchestration/llm_loop.py
+++ b/autoqec/orchestration/llm_loop.py
@@ -61,6 +61,11 @@ def _parse_metrics(round_dir: Path) -> dict[str, Any] | None:
     return metrics if isinstance(metrics, dict) else None
 
 
+def _verify_shots_for_profile(env: EnvSpec, profile: str) -> int:
+    cap = 2048 if profile == "dev" else 8192
+    return min(env.eval_protocol.min_shots_verify, cap)
+
+
 def _round_is_complete(run_dir: Path, round_idx: int, history_rows: dict[int, dict[str, Any]]) -> bool:
     """Return True when a previous invocation durably completed ``round_idx``.
 
@@ -195,6 +200,7 @@ def run_llm_loop(
                         checkpoint=round_dir / "checkpoint.pt",
                         env_spec=env,
                         holdout_seeds=holdout,
+                        n_shots=_verify_shots_for_profile(env, profile),
                     )
                     (round_dir / "verification_report.json").write_text(
                         report.model_dump_json(indent=2), encoding="utf-8",

--- a/autoqec/runner/runner.py
+++ b/autoqec/runner/runner.py
@@ -125,6 +125,21 @@ def _paired_delta_ci(
     return bootstrap_ci_mean(delta_per_shot, n_resamples=n_resamples, ci=ci, seed=seed)
 
 
+def _predict_model_outputs(
+    model: torch.nn.Module,
+    syndrome: torch.Tensor,
+    ctx: dict,
+    *,
+    device: str,
+    batch_size: int,
+) -> np.ndarray:
+    outputs: list[torch.Tensor] = []
+    for start in range(0, syndrome.shape[0], batch_size):
+        batch = syndrome[start : start + batch_size].to(device)
+        outputs.append(model(batch, ctx).detach().cpu())
+    return torch.cat(outputs, dim=0).numpy()
+
+
 def _write_metrics(round_dir: Path, metrics: RoundMetrics) -> RoundMetrics:
     (round_dir / "metrics.json").write_text(
         metrics.model_dump_json(indent=2),
@@ -357,7 +372,13 @@ def run_round(
 
     model.eval()
     with torch.no_grad():
-        pred_out = model(val_syndrome.to(device), ctx).cpu().numpy()
+        pred_out = _predict_model_outputs(
+            model,
+            val_syndrome,
+            ctx,
+            device=device,
+            batch_size=batch_size,
+        )
     pred_labels = decode_with_predecoder(
         pred_out,
         env_spec,

--- a/demos/demo-7-gpu-positive-ai-loop/README.md
+++ b/demos/demo-7-gpu-positive-ai-loop/README.md
@@ -1,0 +1,61 @@
+# Demo 7 — GPU Positive AI Loop
+
+Shows the live AutoQEC loop running from one shell command:
+
+```bash
+bash demos/demo-7-gpu-positive-ai-loop/run.sh
+```
+
+That command uses `cli.autoqec run` without `--no-llm`, so the project AI
+executes the full loop:
+
+`Ideator -> Coder -> Runner -> Analyst -> history.jsonl + orchestrator_trace.md`
+
+## Backend setup
+
+The launcher respects the standard role backend environment variables. On the
+server used for the committed evidence, Claude CLI credentials were valid and
+the Codex CLI OpenAI key returned 401, so the run used:
+
+```bash
+AUTOQEC_IDEATOR_BACKEND=claude-cli \
+AUTOQEC_IDEATOR_MODEL=claude-haiku-4-5 \
+AUTOQEC_CODER_BACKEND=claude-cli \
+AUTOQEC_CODER_MODEL=claude-haiku-4-5 \
+AUTOQEC_ANALYST_BACKEND=claude-cli \
+AUTOQEC_ANALYST_MODEL=claude-haiku-4-5 \
+bash demos/demo-7-gpu-positive-ai-loop/run.sh
+```
+
+Defaults are `ROUNDS=1`, `PROFILE=prod`, and
+`ENV_YAML=autoqec/envs/builtin/surface_d5_depol.yaml`.
+
+## Evidence run
+
+The reference run was produced on 2026-04-25 in the `feat/gpu-positive-demo`
+worktree on an RTX 4090:
+
+- run id: `20260425-234335`
+- trace sections: Ideator response, Coder response, Runner metrics, Analyst
+  response, run complete
+- status: `ok`
+- plain MWPM LER: `0.013916015625`
+- neural-predecoder LER: `0.0130615234375`
+- `delta_ler`: `+0.0008544921875`
+- VRAM peak: `1.94 GB`
+- training loss: `0.013585 -> 0.003462`
+
+The compact committed snapshot lives at
+`expected_output/live_loop_positive_summary.json`. Full runtime artifacts
+remain under `runs/` and are intentionally not committed.
+
+## Why This Demo Exists
+
+Demo 1 and Demo 2 prove the runner and existing surface/qLDPC paths. Demo 7
+proves the live AI loop can be started by one command, produce an agent trace,
+train on GPU, and record a positive surface-code delta in the normal run
+layout.
+
+The Analyst verdict may still be `ignore` when the confidence interval crosses
+zero. That is expected: this demo's claim is a positive training/eval result
+with complete loop artifacts, not a verified Pareto admission.

--- a/demos/demo-7-gpu-positive-ai-loop/expected_output/live_loop_positive_summary.json
+++ b/demos/demo-7-gpu-positive-ai-loop/expected_output/live_loop_positive_summary.json
@@ -1,0 +1,38 @@
+{
+  "run_id": "20260425-234335",
+  "command": "AUTOQEC_IDEATOR_BACKEND=claude-cli AUTOQEC_CODER_BACKEND=claude-cli AUTOQEC_ANALYST_BACKEND=claude-cli bash demos/demo-7-gpu-positive-ai-loop/run.sh",
+  "env_yaml": "autoqec/envs/builtin/surface_d5_depol.yaml",
+  "profile": "prod",
+  "rounds": 1,
+  "agent_trace": {
+    "file": "orchestrator_trace.md",
+    "sections": [
+      "ideator response",
+      "coder response",
+      "runner metrics",
+      "analyst response",
+      "run complete"
+    ]
+  },
+  "metrics": {
+    "status": "ok",
+    "ler_plain_classical": 0.013916015625,
+    "ler_predecoder": 0.0130615234375,
+    "delta_ler": 0.0008544921875,
+    "delta_ler_ci_low": -0.0009796142578124972,
+    "delta_ler_ci_high": 0.0028076171875,
+    "n_params": 75137,
+    "flops_per_syndrome": 72039456,
+    "train_wallclock_s": 149.84471011161804,
+    "eval_wallclock_s": 113.482417345047,
+    "vram_peak_gb": 1.938535424,
+    "train_loss_initial": 0.013585210777819157,
+    "train_loss_final": 0.003462344640865922,
+    "train_batches_total": 640
+  },
+  "history_record": {
+    "hypothesis": "Train a compact 2-layer residual GNN predecoder on the surface_d5 syndrome graph with shared message-passing weights, small hidden width, and dropout tuned for the low-p regime. The goal is to nudge MWPM with a lightweight learned prior without adding much inference cost.",
+    "verdict": "ignore",
+    "summary_1line": "The round reduced LER from 0.013916 to 0.013062, but the 95% CI for delta LER spans zero (-0.000980 to 0.002808)."
+  }
+}

--- a/demos/demo-7-gpu-positive-ai-loop/run.sh
+++ b/demos/demo-7-gpu-positive-ai-loop/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+source "$REPO_ROOT/demos/_lib/python_bin.sh"
+
+PYTHON_BIN="${PYTHON_BIN:-$(discover_demo_python "$REPO_ROOT")}"
+ENV_YAML="${ENV_YAML:-autoqec/envs/builtin/surface_d5_depol.yaml}"
+ROUNDS="${ROUNDS:-1}"
+PROFILE="${PROFILE:-prod}"
+
+cd "$REPO_ROOT"
+exec "$PYTHON_BIN" -m cli.autoqec run "$ENV_YAML" --rounds "$ROUNDS" --profile "$PROFILE"

--- a/docs/contracts/interfaces.md
+++ b/docs/contracts/interfaces.md
@@ -137,7 +137,7 @@ class PredecoderModule(nn.Module):
 
 - Ideator: `{"hypothesis": str, "expected_delta_ler": float, "expected_cost_s": int, "rationale": str, "dsl_hint": dict?}`
 - Coder: `{"dsl_config": {...}, "tier": "1" | "2", "rationale": str}`
-- Analyst: `{"summary_1line": str, "verdict": "candidate" | "ignore", "next_hypothesis_seed": str}`
+- Analyst: `{"summary_1line": str, "verdict": "candidate" | "ignore", "next_hypothesis_seed": str, "branch": str?, "commit_sha": str?}`
 
 ## 2.6 Skill surface
 

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -43,7 +43,13 @@ def test_invoke_subagent_returns_parsed(monkeypatch):
     captured = {}
 
     class FakeCompleted:
-        stdout = '```json\n{"hypothesis": "try GNN", "fork_from": "baseline"}\n```'
+        stdout = (
+            "```json\n"
+            '{"hypothesis": "try GNN", "expected_delta_ler": 0.001, '
+            '"expected_cost_s": 60, "rationale": "fits budget", '
+            '"fork_from": "baseline"}\n'
+            "```"
+        )
         stderr = ""
         returncode = 0
 
@@ -58,6 +64,41 @@ def test_invoke_subagent_returns_parsed(monkeypatch):
     assert captured["kwargs"]["errors"] == "replace"
     assert captured["kwargs"]["env"]["PYTHONIOENCODING"] == "utf-8"
     assert captured["kwargs"]["env"]["PYTHONUTF8"] == "1"
+
+
+def test_invoke_subagent_normalizes_analyst_aliases(monkeypatch):
+    monkeypatch.setenv("AUTOQEC_ANALYST_BACKEND", "claude-cli")
+    monkeypatch.setenv("AUTOQEC_ANALYST_MODEL", "claude-haiku-4-5")
+
+    class FakeCompleted:
+        stdout = (
+            "```json\n"
+            '{"summary": "ran and improved slightly", "classification": "ignore"}\n'
+            "```"
+        )
+        stderr = ""
+        returncode = 0
+
+    with patch("subprocess.run", return_value=FakeCompleted()):
+        out = invoke_subagent("analyst", "prompt")
+
+    assert out["summary_1line"] == "ran and improved slightly"
+    assert out["verdict"] == "ignore"
+    assert out["next_hypothesis_seed"] == "continue from analyst summary"
+
+
+def test_invoke_subagent_rejects_schema_drift(monkeypatch):
+    monkeypatch.setenv("AUTOQEC_IDEATOR_BACKEND", "codex-cli")
+    monkeypatch.setenv("AUTOQEC_IDEATOR_MODEL", "gpt-5.4")
+
+    class FakeCompleted:
+        stdout = '```json\n{"hypothesis": "missing required fields"}\n```'
+        stderr = ""
+        returncode = 0
+
+    with patch("subprocess.run", return_value=FakeCompleted()):
+        with pytest.raises(InvalidSubagentResponseError, match="Invalid ideator response"):
+            invoke_subagent("ideator", "prompt")
 
 
 def test_invoke_subagent_propagates_nonzero(monkeypatch):

--- a/tests/test_demo7_gpu_positive.py
+++ b/tests/test_demo7_gpu_positive.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEMO = ROOT / "demos/demo-7-gpu-positive-ai-loop"
+
+
+def test_demo7_readme_documents_one_command_ai_loop() -> None:
+    text = (DEMO / "README.md").read_text(encoding="utf-8")
+
+    assert "bash demos/demo-7-gpu-positive-ai-loop/run.sh" in text
+    assert "without `--no-llm`" in text
+    assert "orchestrator_trace.md" in text
+    assert "delta_ler" in text
+
+
+def test_demo7_positive_summary_has_trace_and_positive_delta() -> None:
+    summary = json.loads(
+        (DEMO / "expected_output/live_loop_positive_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert summary["metrics"]["status"] == "ok"
+    assert summary["metrics"]["delta_ler"] > 0
+    assert summary["metrics"]["ler_predecoder"] < summary["metrics"]["ler_plain_classical"]
+    assert "runner metrics" in summary["agent_trace"]["sections"]
+    assert "run complete" in summary["agent_trace"]["sections"]

--- a/tests/test_gnn_module.py
+++ b/tests/test_gnn_module.py
@@ -32,6 +32,45 @@ def test_gnn_forward_shape() -> None:
     assert out.shape == (4, n_var)
 
 
+def test_gnn_soft_priors_initializes_from_physical_prior() -> None:
+    """Soft-prior GNNs should learn residuals around the native DEM prior.
+
+    Starting from random probabilities near 0.5 badly miscalibrates MWPM
+    reweighting on sparse QEC errors. With a ``prior_p`` context, an untrained
+    model should initially emit those priors exactly.
+    """
+    n_var, n_check = 5, 3
+    model = BipartiteGNN(
+        n_var=n_var,
+        n_check=n_check,
+        hidden_dim=8,
+        layers=1,
+        message_fn="mlp",
+        aggregation="sum",
+        normalization="none",
+        residual=False,
+        output_mode="soft_priors",
+    )
+    syndrome = torch.rand(2, n_check)
+    edge_index = torch.stack(
+        torch.meshgrid(torch.arange(n_var), torch.arange(n_check), indexing="ij"),
+        dim=0,
+    ).reshape(2, -1)
+    prior_p = torch.tensor([0.001, 0.002, 0.004, 0.008, 0.016])
+
+    out = model(
+        syndrome,
+        {
+            "edge_index": edge_index,
+            "n_var": n_var,
+            "n_check": n_check,
+            "prior_p": prior_p,
+        },
+    )
+
+    assert torch.allclose(out, prior_p.expand_as(out), atol=1e-7)
+
+
 def test_gnn_hard_flip_shape() -> None:
     model = BipartiteGNN(
         n_var=10,

--- a/tests/test_interfaces_contract.py
+++ b/tests/test_interfaces_contract.py
@@ -138,6 +138,8 @@ EXPECTED_FIELDS: dict[str, set[str]] = {
         "summary_1line",
         "verdict",
         "next_hypothesis_seed",
+        "branch",
+        "commit_sha",
     },
 }
 

--- a/tests/test_llm_loop.py
+++ b/tests/test_llm_loop.py
@@ -62,6 +62,7 @@ def test_run_llm_loop_happy_path(tmp_path, monkeypatch):
         model_dump=MagicMock(return_value={"verdict": "SUSPICIOUS",
                                            "delta_vs_baseline_holdout": None}),
     )
+    captured_verify = {}
 
     responses = {"ideator": [], "coder": [], "analyst": []}
 
@@ -80,9 +81,13 @@ def test_run_llm_loop_happy_path(tmp_path, monkeypatch):
         captured_configs.append(cfg)
         return stub_metrics
 
+    def fake_independent_verify(**kwargs):
+        captured_verify.update(kwargs)
+        return stub_report
+
     with patch("autoqec.orchestration.llm_loop.invoke_subagent", side_effect=fake_invoke), \
          patch("autoqec.orchestration.llm_loop.run_round", side_effect=fake_run_round), \
-         patch("autoqec.orchestration.llm_loop.independent_verify", return_value=stub_report):
+         patch("autoqec.orchestration.llm_loop.independent_verify", side_effect=fake_independent_verify):
         run_dir = run_llm_loop(
             env=env,
             rounds=2,
@@ -99,6 +104,7 @@ def test_run_llm_loop_happy_path(tmp_path, monkeypatch):
     assert captured_configs[0].invocation_argv == [
         "python", "-m", "cli.autoqec", "run", "autoqec/envs/builtin/surface_d5_depol.yaml",
     ]
+    assert captured_verify["n_shots"] == 2048
 
     # Trace file captures the chat-level narrative (C route).
     trace = (run_dir / "orchestrator_trace.md")

--- a/tests/test_runner_core.py
+++ b/tests/test_runner_core.py
@@ -377,6 +377,34 @@ def test_run_round_populates_delta_ler_ci_bounds(monkeypatch, tmp_path) -> None:
     )
 
 
+def test_predict_model_outputs_batches_eval_forward_pass() -> None:
+    class CountingModel(torch.nn.Module):
+        output_mode = "soft_priors"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.batch_sizes: list[int] = []
+
+        def forward(self, syndrome: torch.Tensor, ctx: dict) -> torch.Tensor:
+            self.batch_sizes.append(int(syndrome.shape[0]))
+            return torch.full((syndrome.shape[0], 2), 0.125)
+
+    model = CountingModel()
+    syndrome = torch.zeros((5, 3), dtype=torch.float32)
+
+    out = runner._predict_model_outputs(
+        model,
+        syndrome,
+        {},
+        device="cpu",
+        batch_size=2,
+    )
+
+    assert out.shape == (5, 2)
+    assert model.batch_sizes == [2, 2, 1]
+    assert np.allclose(out, 0.125)
+
+
 def test_stim_soft_priors_training_target_is_errors_not_syndrome(monkeypatch, tmp_path) -> None:
     """Regression (2026-04-24): soft_priors BCE target on stim_circuit must
     be the DEM errors (shape (B, n_var)), not the raw syndrome


### PR DESCRIPTION
## Summary
- Anchor GNN soft-prior outputs around native physical priors and batch eval forward passes to avoid prod-profile GPU OOM.
- Validate CLI subagent responses against role schemas, normalize common Analyst aliases, and cap live-loop verifier shots by profile.
- Add Demo 7: one-command live AI loop with a committed positive GPU run summary and trace expectations.

## Evidence
- Live all-Claude prod loop completed: runs/20260425-234335.
- Metrics: plain LER 0.013916015625, predecoder LER 0.0130615234375, delta_ler=+0.0008544921875, VRAM peak 1.94 GB.
- Trace included Ideator, Coder, Runner metrics, Analyst, record, and run-complete sections.

## Verification
- ruff check autoqec cli tests scripts
- PYTHON=/home/tx/QuAIR/qec-ai-decoder/.venv/bin/python PYTEST=/home/tx/QuAIR/qec-ai-decoder/.venv/bin/pytest make test -> 406 passed, 2 skipped, 10 deselected

## Notes
- Codex CLI on this server returned 401 for the configured OpenAI key, so the live evidence run used Claude CLI backends for all roles.